### PR TITLE
Backend authentication and authorization

### DIFF
--- a/apps/api/app/Http/Controllers/Api/V1/CurrentUserController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/CurrentUserController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CurrentUserController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        return response()->json([
+            'user' => $user,
+            'permissions' => [
+                'admin' => $user->isAdmin(),
+                'manage_posts' => $user->isEditor(),
+            ],
+        ]);
+    }
+}

--- a/apps/api/app/Http/Middleware/EnsureAdmin.php
+++ b/apps/api/app/Http/Middleware/EnsureAdmin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureAdmin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (! $request->user()?->isAdmin()) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/apps/api/app/Models/User.php
+++ b/apps/api/app/Models/User.php
@@ -19,31 +19,32 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $fillable = [
-        'name',
+        'supabase_user_id',
         'email',
-        'password',
+        'display_name',
+        'first_name',
+        'last_name',
+        'avatar_url',
+        'role',
     ];
 
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
+    protected $hidden = [];
 
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
+            'supabase_user_id' => 'string',
         ];
     }
+
+    public function isAdmin(): bool
+    {
+        return $this->role === 'admin';
+    }
+
+    public function isEditor(): bool
+    {
+        return in_array($this->role, ['admin', 'editor'], true);
+    }
+
 }

--- a/apps/api/app/Providers/AppServiceProvider.php
+++ b/apps/api/app/Providers/AppServiceProvider.php
@@ -3,6 +3,10 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\User;
+use App\Services\Auth\SupabaseTokenVerifier;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +23,31 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Auth::viaRequest('supabase', function (Request $request) {
+            $token = $request->bearerToken();
+
+            if (!$token) {
+                return null;
+            }
+
+            try {
+                $claims = app(SupabaseTokenVerifier::class)->verify($token);
+            } catch (\Throwable) {
+                return null;
+            }
+
+            $userMetadata = $claims->user_metadata ?? null;
+
+            return User::firstOrCreate(
+                ['supabase_user_id' => $claims->sub],
+                [
+                    'email' => $claims->email ?? '',
+                    'display_name' => $userMetadata->display_name ?? null,
+                    'avatar_url' => $userMetadata->avatar_url ?? null,
+                    'role' => 'user',
+                ]
+            );
+        });
     }
+
 }

--- a/apps/api/app/Services/Auth/SupabaseTokenVerifier.php
+++ b/apps/api/app/Services/Auth/SupabaseTokenVerifier.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class SupabaseTokenVerifier
+{
+    public function verify(string $token): object
+    {
+        $jwks = Cache::remember('supabase.jwks', now()->addMinutes(10), function () {
+            $response = Http::get(config('services.supabase.jwks_url'));
+
+            if (! $response->successful()) {
+                throw new RuntimeException('Unable to fetch Supabase JWKS.');
+            }
+
+            return $response->json();
+        });
+
+        $keys = JWK::parseKeySet($jwks);
+        $claims = JWT::decode($token, $keys);
+
+        if (($claims->iss ?? null) !== config('services.supabase.issuer')) {
+            throw new RuntimeException('Invalid token issuer.');
+        }
+
+        $expectedAudience = config('services.supabase.audience');
+        $actualAudience = $claims->aud ?? null;
+
+        $validAudience = is_array($actualAudience)
+            ? in_array($expectedAudience, $actualAudience, true)
+            : $actualAudience === $expectedAudience;
+
+        if (! $validAudience) {
+            throw new RuntimeException('Invalid token audience.');
+        }
+
+        if (empty($claims->sub)) {
+            throw new RuntimeException('Missing token subject.');
+        }
+
+        return $claims;
+    }
+}

--- a/apps/api/bootstrap/app.php
+++ b/apps/api/bootstrap/app.php
@@ -7,12 +7,20 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->redirectGuestsTo(fn () => null);
+
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\EnsureAdmin::class,
+        ]);
     })
+
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->shouldRenderJsonWhen(function ($request): bool {
+            return $request->is('api/*') || $request->expectsJson();
+        });
     })->create();

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "firebase/php-jwt": "^7.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1"
     },
@@ -42,10 +43,6 @@
             "npm install",
             "npm run build"
         ],
-        // "dev": [
-        //     "Composer\\Config::disableProcessTimeout",
-        //     "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
-        // ],
         "dev":[
             "php artisan serve"
         ],

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76e8c0bf895ed4d2c6d62b233b8c7f74",
+    "content-hash": "2ad831ec606caab3773c370fc914e495",
     "packages": [
         {
             "name": "brick/math",
@@ -507,6 +507,70 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v7.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
+            },
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/apps/api/config/auth.php
+++ b/apps/api/config/auth.php
@@ -42,6 +42,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'api' => [
+            'driver' => 'supabase',
+        ],
     ],
 
     /*

--- a/apps/api/config/cors.php
+++ b/apps/api/config/cors.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['api/*'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => [
+        env('FRONTEND_URL', 'http://localhost:3000'),
+    ],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => false,
+
+];

--- a/apps/api/config/services.php
+++ b/apps/api/config/services.php
@@ -35,4 +35,12 @@ return [
         ],
     ],
 
+    'supabase' => [
+        'url' => env('SUPABASE_URL'),
+        'jwks_url' => env('SUPABASE_JWKS_URL'),
+        'issuer' => env('SUPABASE_JWT_ISSUER'),
+        'audience' => env('SUPABASE_JWT_AUDIENCE', 'authenticated'),
+    ],
+
+
 ];

--- a/apps/api/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/apps/api/database/migrations/0001_01_01_000000_create_users_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -13,11 +12,13 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->uuid('supabase_user_id')->unique();
             $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
+            $table->string('display_name')->nullable();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('avatar_url')->nullable();
+            $table->string('role')->default('user');
             $table->timestamps();
         });
 

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1')->group(function () {
+    Route::get('/posts', fn () => response()->json([]));
+    Route::get('/categories', fn () => response()->json([]));
+
+    Route::middleware('auth:api')->group(function () {
+        Route::get('/me', \App\Http\Controllers\Api\V1\CurrentUserController::class);
+
+        Route::middleware('admin')->prefix('admin')->group(function () {
+            Route::get('/posts', fn () => response()->json([]));
+            Route::post('/posts', fn () => response()->json([], 201));
+            Route::put('/posts/{post}', fn () => response()->json([]));
+            Route::delete('/posts/{post}', fn () => response()->json([], 204));
+            Route::post('/uploads', fn () => response()->json([], 201));
+        });
+    });
+
+    Route::post('/posts/{slug}/view', fn () => response()->json([], 202));
+});

--- a/docs/architecture/auth-authorization.md
+++ b/docs/architecture/auth-authorization.md
@@ -8,6 +8,58 @@ This document defines the target frontend authentication and authorization struc
 - `apps/api` owns JSON APIs, Supabase token verification, authorization, policies, models, and persistence.
 - `legacy/symfony-blog` is reference-only and must not drive the new auth structure.
 
+## Implementation Progress
+
+```text
+1. Frontend auth UI foundation     done
+2. Backend/Supabase auth setup     done
+3. Frontend auth wiring            next
+4. Authorization guards/roles      partially started
+```
+
+Backend/Supabase setup currently includes the `auth:api` guard, Supabase bearer-token verification through JWKS, local `users.supabase_user_id` mapping, `GET /api/v1/me`, CORS config, JSON `401` behavior for API routes, and the initial admin middleware/role helpers.
+
+## Backend Auth Implementation
+
+Protected API routes use Laravel's built-in `auth` middleware with the custom `api` guard:
+
+```php
+Route::middleware('auth:api')->group(function () {
+    Route::get('/me', \App\Http\Controllers\Api\V1\CurrentUserController::class);
+});
+```
+
+The backend request flow is:
+
+```text
+GET /api/v1/me
+└── auth:api middleware
+    └── api guard from apps/api/config/auth.php
+        └── supabase driver registered in AppServiceProvider
+            └── read Authorization: Bearer <token>
+                └── SupabaseTokenVerifier verifies token through JWKS
+                    └── claims.sub maps to users.supabase_user_id
+                        └── User::firstOrCreate resolves local app user
+                            └── CurrentUserController reads $request->user()
+```
+
+Authentication outcomes:
+
+```text
+No token      -> guard returns null -> 401
+Invalid token -> guard returns null -> 401
+Valid token   -> guard returns User -> controller runs
+```
+
+Supabase Auth remains the identity source. Laravel does not store passwords or implement password login/register for this rebuild. Laravel stores the local app user record, role, profile metadata, and future relationships such as post authorship.
+
+```text
+Supabase Auth user id
+└── token claims.sub
+    └── users.supabase_user_id
+        └── local users.id for Laravel relationships
+```
+
 ## Route Structure
 
 Use one centralized signin and signup experience for every account type.


### PR DESCRIPTION
## Summary

- Added Supabase-backed API authentication setup for Laravel.
- Added `/api/v1/me` current-user endpoint protected by `auth:api`.
- Added Supabase JWKS token verification and local user mapping via `users.supabase_user_id`.
- Added initial admin middleware, CORS config, and API JSON `401` behavior.
- Updated auth architecture docs with implementation progress and backend flow.

## Reason

This prepares the backend contract needed for frontend auth wiring. Supabase owns login/session identity, while Laravel verifies bearer tokens, resolves local users, and owns app roles/authorization.

## Changed Areas

- `apps/api/routes/api.php`
- `apps/api/config/auth.php`
- `apps/api/config/services.php`
- `apps/api/config/cors.php`
- `apps/api/app/Services/Auth/SupabaseTokenVerifier.php`
- `apps/api/app/Providers/AppServiceProvider.php`
- `apps/api/app/Http/Controllers/Api/V1/CurrentUserController.php`
- `apps/api/app/Http/Middleware/EnsureAdmin.php`
- `apps/api/app/Models/User.php`
- `apps/api/database/migrations/0001_01_01_000000_create_users_table.php`
- `docs/architecture/auth-authorization.md`

## Notes

- Laravel does not store passwords or handle password login/register.
- Supabase Auth remains the identity source.
- Laravel stores local app user records, roles, and future content relationships.
- Frontend auth wiring is the next step.
