### PR TITLE
Wiring authentication and authorization

### DIFF
--- a/apps/api/app/Models/User.php
+++ b/apps/api/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
     protected $fillable = [
         'supabase_user_id',
         'email',
+        'handle',
         'display_name',
         'first_name',
         'last_name',

--- a/apps/api/app/Providers/AppServiceProvider.php
+++ b/apps/api/app/Providers/AppServiceProvider.php
@@ -7,6 +7,8 @@ use App\Models\User;
 use App\Services\Auth\SupabaseTokenVerifier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -32,22 +34,84 @@ class AppServiceProvider extends ServiceProvider
 
             try {
                 $claims = app(SupabaseTokenVerifier::class)->verify($token);
-            } catch (\Throwable) {
+            } catch (\Throwable $exception) {
+                Log::warning('Supabase token verification failed.', [
+                    'message' => $exception->getMessage(),
+                    'exception' => $exception::class,
+                ]);
+
                 return null;
             }
 
             $userMetadata = $claims->user_metadata ?? null;
+            $email = $claims->email ?? '';
 
-            return User::firstOrCreate(
-                ['supabase_user_id' => $claims->sub],
-                [
-                    'email' => $claims->email ?? '',
-                    'display_name' => $userMetadata->display_name ?? null,
-                    'avatar_url' => $userMetadata->avatar_url ?? null,
-                    'role' => 'user',
-                ]
-            );
+            $user = User::where('supabase_user_id', $claims->sub)->first()
+                ?? User::where('email', $email)->first();
+
+            if ($user) {
+                $user->fill([
+                    'supabase_user_id' => $user->supabase_user_id ?? $claims->sub,
+                    'handle' => $user->handle ?? $this->resolveHandle($userMetadata, $email, $user),
+                    'display_name' => $user->display_name ?? $userMetadata->display_name ?? $userMetadata->full_name ?? null,
+                    'avatar_url' => $user->avatar_url ?? $userMetadata->avatar_url ?? $userMetadata->picture ?? null,
+                ])->save();
+
+                return $user;
+            }
+
+            return User::create([
+                'supabase_user_id' => $claims->sub,
+                'email' => $email,
+                'handle' => $this->resolveHandle($userMetadata, $email),
+                'display_name' => $userMetadata->display_name ?? $userMetadata->full_name ?? null,
+                'avatar_url' => $userMetadata->avatar_url ?? $userMetadata->picture ?? null,
+                'role' => 'user',
+            ]);
         });
+    }
+
+    private function resolveHandle(?object $userMetadata, string $email, ?User $currentUser = null): string
+    {
+        $source = $userMetadata->handle
+            ?? $userMetadata->user_name
+            ?? $userMetadata->preferred_username
+            ?? $userMetadata->full_name
+            ?? $userMetadata->name
+            ?? Str::before($email, '@')
+            ?? 'user';
+
+        $base = $this->normalizeHandleBase((string) $source);
+        $candidate = '@'.$base;
+        $suffix = 2;
+
+        while ($this->handleExists($candidate, $currentUser)) {
+            $suffixText = (string) $suffix;
+            $candidate = '@'.substr($base, 0, 19 - strlen($suffixText)).$suffixText;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+
+    private function normalizeHandleBase(string $source): string
+    {
+        $base = Str::of($source)
+            ->lower()
+            ->replaceMatches('/^@/', '')
+            ->replaceMatches('/[^a-z0-9_]+/', '_')
+            ->trim('_')
+            ->limit(19, '')
+            ->toString();
+
+        return $base !== '' && strlen($base) >= 2 ? $base : 'user';
+    }
+
+    private function handleExists(string $handle, ?User $currentUser = null): bool
+    {
+        return User::where('handle', $handle)
+            ->when($currentUser, fn ($query) => $query->whereKeyNot($currentUser->getKey()))
+            ->exists();
     }
 
 }

--- a/apps/api/app/Providers/AppServiceProvider.php
+++ b/apps/api/app/Providers/AppServiceProvider.php
@@ -53,8 +53,8 @@ class AppServiceProvider extends ServiceProvider
                 $user->fill([
                     'supabase_user_id' => $user->supabase_user_id ?? $claims->sub,
                     'handle' => $user->handle ?? $this->resolveHandle($userMetadata, $email, $user),
-                    'display_name' => $user->display_name ?? $userMetadata->display_name ?? $userMetadata->full_name ?? null,
-                    'avatar_url' => $user->avatar_url ?? $userMetadata->avatar_url ?? $userMetadata->picture ?? null,
+                    'display_name' => $user->display_name ?? $userMetadata?->display_name ?? $userMetadata?->full_name,
+                    'avatar_url' => $user->avatar_url ?? $userMetadata?->avatar_url ?? $userMetadata?->picture,
                 ])->save();
 
                 return $user;
@@ -64,8 +64,8 @@ class AppServiceProvider extends ServiceProvider
                 'supabase_user_id' => $claims->sub,
                 'email' => $email,
                 'handle' => $this->resolveHandle($userMetadata, $email),
-                'display_name' => $userMetadata->display_name ?? $userMetadata->full_name ?? null,
-                'avatar_url' => $userMetadata->avatar_url ?? $userMetadata->picture ?? null,
+                'display_name' => $userMetadata?->display_name ?? $userMetadata?->full_name,
+                'avatar_url' => $userMetadata?->avatar_url ?? $userMetadata?->picture,
                 'role' => 'user',
             ]);
         });
@@ -73,11 +73,11 @@ class AppServiceProvider extends ServiceProvider
 
     private function resolveHandle(?object $userMetadata, string $email, ?User $currentUser = null): string
     {
-        $source = $userMetadata->handle
-            ?? $userMetadata->user_name
-            ?? $userMetadata->preferred_username
-            ?? $userMetadata->full_name
-            ?? $userMetadata->name
+        $source = $userMetadata?->handle
+            ?? $userMetadata?->user_name
+            ?? $userMetadata?->preferred_username
+            ?? $userMetadata?->full_name
+            ?? $userMetadata?->name
             ?? Str::before($email, '@')
             ?? 'user';
 

--- a/apps/api/database/factories/UserFactory.php
+++ b/apps/api/database/factories/UserFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
@@ -13,33 +12,25 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
-
-    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
-        return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
-        ];
-    }
+        $handle = fake()->unique()->userName();
 
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
+        return [
+            'supabase_user_id' => fake()->uuid(),
+            'email' => fake()->unique()->safeEmail(),
+            'handle' => '@'.Str::of($handle)
+                ->lower()
+                ->replaceMatches('/[^a-z0-9_]+/', '_')
+                ->trim('_')
+                ->limit(19, ''),
+            'display_name' => fake()->name(),
+            'avatar_url' => fake()->optional()->imageUrl(),
+            'role' => 'user',
+        ];
     }
 }

--- a/apps/api/database/migrations/2026_05_05_000000_add_handle_to_users_table.php
+++ b/apps/api/database/migrations/2026_05_05_000000_add_handle_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('handle', 32)->nullable()->unique()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['handle']);
+            $table->dropColumn('handle');
+        });
+    }
+};

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@supabase/supabase-js": "^2.105.1",
         "@tailwindcss/vite": "^4.2.4",
         "lucide-react": "^1.14.0",
         "react": "^19.2.5",
@@ -1094,6 +1095,92 @@
         }
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.1.tgz",
+      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.1.tgz",
+      "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.1.tgz",
+      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.1.tgz",
+      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.1",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.1.tgz",
+      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.1.tgz",
+      "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.1",
+        "@supabase/functions-js": "2.105.1",
+        "@supabase/postgrest-js": "2.105.1",
+        "@supabase/realtime-js": "2.105.1",
+        "@supabase/storage-js": "2.105.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -1597,7 +1684,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -1621,6 +1707,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@universal-deploy/netlify": {
@@ -2132,6 +2227,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -2925,7 +3029,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {
@@ -2946,7 +3049,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3141,6 +3243,27 @@
       "license": "MIT",
       "peerDependencies": {
         "vite": ">=7"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@supabase/supabase-js": "^2.105.1",
     "@tailwindcss/vite": "^4.2.4",
     "lucide-react": "^1.14.0",
     "react": "^19.2.5",

--- a/apps/web/pages/(auth)/auth/callback/+Page.tsx
+++ b/apps/web/pages/(auth)/auth/callback/+Page.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { fetchCurrentUser } from "@/features/auth/api/currentUserApi";
 import { AuthShell } from "@/layouts/AuthShell";
 import { supabase } from "@/lib/auth/supabaseClient";
-
-type CallbackStatus = "loading" | "error";
+import type { CallbackStatus, SocialAuthProvider } from "@/features/auth/authTypes";
+import {
+  clearPendingAuthProvider,
+  getPendingAuthProvider,
+  setLastAuthProvider,
+} from "@/features/auth/lib/lastAuthProvider";
 
 export default function Page() {
+  const hasStarted = useRef(false);
   const [status, setStatus] = useState<CallbackStatus>("loading");
   const [message, setMessage] = useState("Confirming your account and opening your session.");
 
@@ -16,14 +21,26 @@ export default function Page() {
   }
 
   useEffect(() => {
+    if (hasStarted.current) return;
+    hasStarted.current = true;
+
     async function finishAuth() {
+      const url = new URL(window.location.href);
+      const authCode = url.searchParams.get("code");
       const hashParams = new URLSearchParams(
         window.location.hash.replace(/^#/, ""),
       );
       const hashAccessToken = hashParams.get("access_token");
       const hashRefreshToken = hashParams.get("refresh_token");
 
-      if (hashAccessToken && hashRefreshToken) {
+      if (authCode) {
+        const { error } = await supabase.auth.exchangeCodeForSession(authCode);
+
+        if (error) {
+          showError(error.message);
+          return;
+        }
+      } else if (hashAccessToken && hashRefreshToken) {
         const { error } = await supabase.auth.setSession({
           access_token: hashAccessToken,
           refresh_token: hashRefreshToken,
@@ -48,6 +65,13 @@ export default function Page() {
       }
 
       const currentUser = await fetchCurrentUser(data.session.access_token);
+      const provider = getPendingAuthProvider() ?? data.session.user.app_metadata.provider;
+
+      if (provider === "github" || provider === "google") {
+        setLastAuthProvider(provider as SocialAuthProvider);
+      }
+
+      clearPendingAuthProvider();
 
       window.history.replaceState({}, document.title, "/auth/callback");
 
@@ -56,7 +80,7 @@ export default function Page() {
         return;
       }
 
-      window.location.href = "/me";
+      window.location.href = "/";
     }
 
     finishAuth().catch(() => {

--- a/apps/web/pages/(auth)/auth/callback/+Page.tsx
+++ b/apps/web/pages/(auth)/auth/callback/+Page.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+
+import { fetchCurrentUser } from "@/features/auth/api/currentUserApi";
+import { AuthShell } from "@/layouts/AuthShell";
+import { supabase } from "@/lib/auth/supabaseClient";
+
+type CallbackStatus = "loading" | "error";
+
+export default function Page() {
+  const [status, setStatus] = useState<CallbackStatus>("loading");
+  const [message, setMessage] = useState("Confirming your account and opening your session.");
+
+  function showError(nextMessage: string) {
+    setStatus("error");
+    setMessage(nextMessage);
+  }
+
+  useEffect(() => {
+    async function finishAuth() {
+      const hashParams = new URLSearchParams(
+        window.location.hash.replace(/^#/, ""),
+      );
+      const hashAccessToken = hashParams.get("access_token");
+      const hashRefreshToken = hashParams.get("refresh_token");
+
+      if (hashAccessToken && hashRefreshToken) {
+        const { error } = await supabase.auth.setSession({
+          access_token: hashAccessToken,
+          refresh_token: hashRefreshToken,
+        });
+
+        if (error) {
+          showError(error.message);
+          return;
+        }
+      }
+
+      const { data, error } = await supabase.auth.getSession();
+
+      if (error) {
+        showError(error.message);
+        return;
+      }
+
+      if (!data.session?.access_token) {
+        showError("No auth session was found. Please sign in again.");
+        return;
+      }
+
+      const currentUser = await fetchCurrentUser(data.session.access_token);
+
+      window.history.replaceState({}, document.title, "/auth/callback");
+
+      if (currentUser.permissions.admin) {
+        window.location.href = "/dashboard";
+        return;
+      }
+
+      window.location.href = "/me";
+    }
+
+    finishAuth().catch(() => {
+      showError(
+        "Unable to connect this session to the API. Please sign in again.",
+      );
+    });
+  }, []);
+
+  return (
+    <AuthShell side={<CallbackSidePanel />} sidePlacement="start">
+      <div className="auth-callback">
+        <div
+          aria-hidden="true"
+          className={status === "loading" ? "callback-mark is-loading" : "callback-mark is-error"}
+        >
+          {status === "loading" ? "" : "!"}
+        </div>
+
+        <div className="eyebrow mb-4">
+          {status === "loading" ? "Account confirmation" : "Session check"}
+        </div>
+
+        <h1>
+          {status === "loading" ? (
+            <>
+              Finishing <em>sign in</em>.
+            </>
+          ) : (
+            <>
+              Could not finish <em>sign in</em>.
+            </>
+          )}
+        </h1>
+
+        <p className="lede">{message}</p>
+
+        {status === "error" ? (
+          <div className="callback-actions">
+            <a className="btn btn-primary" href="/signin">
+              Back to sign in
+            </a>
+            <a className="btn btn-ghost" href="/signup">
+              Create account
+            </a>
+          </div>
+        ) : (
+          <div className="callback-progress" aria-label="Loading">
+            <span />
+            <span />
+            <span />
+          </div>
+        )}
+      </div>
+    </AuthShell>
+  );
+}
+
+function CallbackSidePanel() {
+  return (
+    <>
+      <div className="brand">
+        <span className="brand-mark">j</span>
+        <span>
+          jymb<span className="brand-dot">.</span>blog
+        </span>
+      </div>
+
+      <div className="side-reset">
+        <h2>
+          One last <em>check</em>.
+        </h2>
+        <p>
+          We are confirming the Supabase session, syncing your local blog
+          profile, and then sending you to the right place.
+        </p>
+        <div className="side-steps">
+          <div className="side-step">
+            <span className="num">01</span>
+            <span>Confirm the token from your email link.</span>
+          </div>
+          <div className="side-step">
+            <span className="num">02</span>
+            <span>Resolve your local Laravel profile.</span>
+          </div>
+          <div className="side-step">
+            <span className="num">03</span>
+            <span>Open your account or dashboard.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="side-meta">
+        <span>Secure callback</span>
+        <span>Supabase + Laravel</span>
+      </div>
+    </>
+  );
+}

--- a/apps/web/pages/(auth)/auth/callback/+Page.tsx
+++ b/apps/web/pages/(auth)/auth/callback/+Page.tsx
@@ -12,10 +12,12 @@ import {
 
 export default function Page() {
   const hasStarted = useRef(false);
+  const [isSilent, setIsSilent] = useState(true);
   const [status, setStatus] = useState<CallbackStatus>("loading");
   const [message, setMessage] = useState("Confirming your account and opening your session.");
 
   function showError(nextMessage: string) {
+    setIsSilent(false);
     setStatus("error");
     setMessage(nextMessage);
   }
@@ -32,6 +34,12 @@ export default function Page() {
       );
       const hashAccessToken = hashParams.get("access_token");
       const hashRefreshToken = hashParams.get("refresh_token");
+      const pendingProvider = getPendingAuthProvider();
+      const shouldShowCallbackUi = !authCode && !pendingProvider;
+
+      if (shouldShowCallbackUi) {
+        setIsSilent(false);
+      }
 
       if (authCode) {
         const { error } = await supabase.auth.exchangeCodeForSession(authCode);
@@ -65,7 +73,7 @@ export default function Page() {
       }
 
       const currentUser = await fetchCurrentUser(data.session.access_token);
-      const provider = getPendingAuthProvider() ?? data.session.user.app_metadata.provider;
+      const provider = pendingProvider ?? data.session.user.app_metadata.provider;
 
       if (provider === "github" || provider === "google") {
         setLastAuthProvider(provider as SocialAuthProvider);
@@ -89,6 +97,10 @@ export default function Page() {
       );
     });
   }, []);
+
+  if (isSilent && status === "loading") {
+    return null;
+  }
 
   return (
     <AuthShell side={<CallbackSidePanel />} sidePlacement="start">

--- a/apps/web/pages/(auth)/forgot-password/+Page.tsx
+++ b/apps/web/pages/(auth)/forgot-password/+Page.tsx
@@ -1,12 +1,10 @@
 import { ForgotPasswordForm } from '@/features/auth/components/ForgotPasswordForm'
-import { ForgotPasswordIntro } from '@/features/auth/components/ForgotPasswordIntro'
 import { ForgotPasswordSidePanel } from '@/features/auth/components/ForgotPasswordSidePanel'
 import { AuthShell } from '@/layouts/AuthShell'
 
 export default function Page() {
   return (
     <AuthShell side={<ForgotPasswordSidePanel />}>
-      <ForgotPasswordIntro />
       <ForgotPasswordForm />
     </AuthShell>
   )

--- a/apps/web/pages/(auth)/reset-password/+Page.tsx
+++ b/apps/web/pages/(auth)/reset-password/+Page.tsx
@@ -1,12 +1,10 @@
 import { ResetPasswordForm } from "@/features/auth/components/ResetPasswordForm";
-import { ResetPasswordIntro } from "@/features/auth/components/ResetPasswordIntro";
 import { ResetPasswordSidePanel } from "@/features/auth/components/ResetPasswordSidePanel";
 import { AuthShell } from "@/layouts/AuthShell";
 
 export default function Page() {
   return (
     <AuthShell side={<ResetPasswordSidePanel />}>
-      <ResetPasswordIntro />
       <ResetPasswordForm />
     </AuthShell>
   );

--- a/apps/web/pages/(auth)/reset-password/+Page.tsx
+++ b/apps/web/pages/(auth)/reset-password/+Page.tsx
@@ -1,0 +1,13 @@
+import { ResetPasswordForm } from "@/features/auth/components/ResetPasswordForm";
+import { ResetPasswordIntro } from "@/features/auth/components/ResetPasswordIntro";
+import { ResetPasswordSidePanel } from "@/features/auth/components/ResetPasswordSidePanel";
+import { AuthShell } from "@/layouts/AuthShell";
+
+export default function Page() {
+  return (
+    <AuthShell side={<ResetPasswordSidePanel />}>
+      <ResetPasswordIntro />
+      <ResetPasswordForm />
+    </AuthShell>
+  );
+}

--- a/apps/web/pages/(auth)/signup/+Page.tsx
+++ b/apps/web/pages/(auth)/signup/+Page.tsx
@@ -1,12 +1,10 @@
 import { SignUpForm } from '@/features/auth/components/SignUpForm'
-import { SignUpIntro } from '@/features/auth/components/SignUpIntro'
 import { SignUpSidePanel } from '@/features/auth/components/SignUpSidePanel'
 import { AuthShell } from '@/layouts/AuthShell'
 
 export default function Page() {
   return (
     <AuthShell side={<SignUpSidePanel />} sidePlacement="start">
-      <SignUpIntro />
       <SignUpForm />
     </AuthShell>
   )

--- a/apps/web/src/features/auth/api/currentUserApi.ts
+++ b/apps/web/src/features/auth/api/currentUserApi.ts
@@ -1,0 +1,14 @@
+export async function fetchCurrentUser(accessToken: string) {
+    const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/me`, {
+        headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error('Unable to load current user.');
+    }
+
+    return response.json();
+}

--- a/apps/web/src/features/auth/api/registerApi.ts
+++ b/apps/web/src/features/auth/api/registerApi.ts
@@ -1,0 +1,41 @@
+import { supabase } from '@/lib/auth/supabaseClient';
+import { fetchCurrentUser } from '@/features/auth/api/currentUserApi';
+
+type RegisterInput = {
+    displayName: string;
+    handle: string;
+    email: string;
+    password: string;
+}
+
+export async function registerWithEmail(params: RegisterInput) {
+    const { data, error } = await supabase.auth.signUp({
+        email: params.email,
+        password: params.password,
+        options: {
+            emailRedirectTo: `${window.location.origin}/auth/callback`,
+            data: {
+                display_name: params.displayName,
+                handle: params.handle,
+            },
+        },
+    });
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    const accessToken = data.session?.access_token;
+
+    if (!accessToken) {
+        return {
+            needsEmailConfirmation: true,
+            currentUser: null,
+        };
+    }
+
+    return {
+        needsEmailConfirmation: false,
+        currentUser: await fetchCurrentUser(accessToken),
+    };
+}

--- a/apps/web/src/features/auth/api/registerApi.ts
+++ b/apps/web/src/features/auth/api/registerApi.ts
@@ -1,5 +1,7 @@
 import { supabase } from '@/lib/auth/supabaseClient';
 import { fetchCurrentUser } from '@/features/auth/api/currentUserApi';
+import type { SocialAuthProvider } from '@/features/auth/authTypes';
+import { setPendingAuthProvider } from '@/features/auth/lib/lastAuthProvider';
 
 type RegisterInput = {
     displayName: string;
@@ -38,4 +40,19 @@ export async function registerWithEmail(params: RegisterInput) {
         needsEmailConfirmation: false,
         currentUser: await fetchCurrentUser(accessToken),
     };
+}
+
+export async function registerWithSocialProvider(provider: SocialAuthProvider) {
+    setPendingAuthProvider(provider);
+
+    const { error } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+            redirectTo: `${window.location.origin}/auth/callback`,
+        },
+    });
+
+    if (error) {
+        throw new Error(error.message);
+    }
 }

--- a/apps/web/src/features/auth/api/registerApi.ts
+++ b/apps/web/src/features/auth/api/registerApi.ts
@@ -42,7 +42,7 @@ export async function registerWithEmail(params: RegisterInput) {
     };
 }
 
-export async function registerWithSocialProvider(provider: SocialAuthProvider) {
+export async function startSocialAuth(provider: SocialAuthProvider) {
     setPendingAuthProvider(provider);
 
     const { error } = await supabase.auth.signInWithOAuth({

--- a/apps/web/src/features/auth/api/resetPasswordApi.ts
+++ b/apps/web/src/features/auth/api/resetPasswordApi.ts
@@ -1,0 +1,68 @@
+import { supabase } from "@/lib/auth/supabaseClient";
+
+export async function sendPasswordResetEmail(email: string) {
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${window.location.origin}/reset-password`,
+  });
+
+  if (error) {
+    throw new Error("Unable to send reset link. Please try again.");
+  }
+}
+
+export async function startPasswordRecoverySession() {
+  const url = new URL(window.location.href);
+  const authCode = url.searchParams.get("code");
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const hashAccessToken = hashParams.get("access_token");
+  const hashRefreshToken = hashParams.get("refresh_token");
+
+  if (authCode) {
+    const { error } = await supabase.auth.exchangeCodeForSession(authCode);
+
+    if (error) {
+      throw new Error("This reset link has expired or was already used.");
+    }
+  } else if (hashAccessToken && hashRefreshToken) {
+    const { error } = await supabase.auth.setSession({
+      access_token: hashAccessToken,
+      refresh_token: hashRefreshToken,
+    });
+
+    if (error) {
+      throw new Error("This reset link has expired or was already used.");
+    }
+  }
+
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error || !data.session?.access_token) {
+    throw new Error("We could not verify this reset link. Please request a new one.");
+  }
+
+  window.history.replaceState({}, document.title, "/reset-password");
+}
+
+export async function updatePassword(newPassword: string) {
+  const { error } = await supabase.auth.updateUser({ password: newPassword });
+
+  if (error) {
+    throw new Error(getPasswordUpdateErrorMessage(error));
+  }
+}
+
+export async function signOutAfterPasswordUpdate() {
+  await supabase.auth.signOut();
+}
+
+function getPasswordUpdateErrorMessage(error: { code?: string; message?: string }) {
+  if (error.code === "same_password") {
+    return "Choose a password you have not used for this account before.";
+  }
+
+  if (error.message?.toLowerCase().includes("same password")) {
+    return "Choose a password you have not used for this account before.";
+  }
+
+  return "Unable to update password. Please try again.";
+}

--- a/apps/web/src/features/auth/api/signInApi.ts
+++ b/apps/web/src/features/auth/api/signInApi.ts
@@ -1,0 +1,32 @@
+import { fetchCurrentUser } from "@/features/auth/api/currentUserApi";
+import { supabase } from "@/lib/auth/supabaseClient";
+import type { SignInInput } from "@/features/auth/authTypes";
+
+export async function signInWithEmail(params: SignInInput) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: params.email,
+    password: params.password,
+  });
+
+  if (error) {
+    throw new Error("We couldn't sign you in with those details.");
+  }
+
+  const accessToken = data.session?.access_token;
+
+  if (!accessToken) {
+    throw new Error("No sign-in session was created. Please try again.");
+  }
+
+  return fetchCurrentUser(accessToken);
+}
+
+export async function getSignedInUser() {
+  const { data, error } = await supabase.auth.getSession();
+
+  if (error || !data.session?.access_token) {
+    return null;
+  }
+
+  return fetchCurrentUser(data.session.access_token);
+}

--- a/apps/web/src/features/auth/authTypes.ts
+++ b/apps/web/src/features/auth/authTypes.ts
@@ -31,3 +31,8 @@ export type AuthProviderButtonsProps = {
 }
 
 export type SocialAuthProvider = 'github' | 'google';
+
+export type SignInInput = {
+  email: string;
+  password: string;
+};

--- a/apps/web/src/features/auth/authTypes.ts
+++ b/apps/web/src/features/auth/authTypes.ts
@@ -20,6 +20,15 @@ export type ForgotPasswordErrors = {
   server?: string;
 };
 
+export type ResetPasswordFields = {
+  password: string;
+  confirmPassword: string;
+};
+
+export type ResetPasswordErrors = Partial<
+  ResetPasswordFields & { server: string }
+>;
+
 export type CallbackStatus = "loading" | "error";
 
 export type AuthProviderButtonsProps = {

--- a/apps/web/src/features/auth/authTypes.ts
+++ b/apps/web/src/features/auth/authTypes.ts
@@ -19,3 +19,15 @@ export type ForgotPasswordErrors = {
   email?: string;
   server?: string;
 };
+
+export type CallbackStatus = "loading" | "error";
+
+export type AuthProviderButtonsProps = {
+  compact?: boolean;
+  disabled?: boolean;
+  lastUsedProvider?: SocialAuthProvider | null;
+  loadingProvider?: SocialAuthProvider | null;
+  onProviderSelect?: (provider: SocialAuthProvider) => void;
+}
+
+export type SocialAuthProvider = 'github' | 'google';

--- a/apps/web/src/features/auth/components/AuthProviderButtons.tsx
+++ b/apps/web/src/features/auth/components/AuthProviderButtons.tsx
@@ -1,21 +1,57 @@
 import GithubIcon from "@/assets/image/github.svg?react";
 import GoogleIcon from "@/assets/image/google.svg?react";
+import type { AuthProviderButtonsProps } from "@/features/auth/authTypes";
 
-interface AuthProviderButtonsProps {
-  compact?: boolean;
-}
+export function AuthProviderButtons({
+  compact = false,
+  disabled = false,
+  lastUsedProvider = null,
+  loadingProvider = null,
+  onProviderSelect,
+}: AuthProviderButtonsProps) {
+  function providerLabel(provider: "github" | "google") {
+    if (loadingProvider === provider) {
+      return `Opening ${provider === "github" ? "GitHub" : "Google"}...`;
+    }
 
-export function AuthProviderButtons({ compact = false }: AuthProviderButtonsProps) {
+    if (compact) {
+      return provider === "github" ? "GitHub" : "Google";
+    }
+
+    return `Continue with ${provider === "github" ? "GitHub" : "Google"}`;
+  }
+
   return (
     <div className={compact ? "oauth-btns oauth-btns-compact" : "oauth-btns"}>
-      <button className="oauth-btn" type="button">
-        <GithubIcon aria-hidden className="oauth-icon" />
-        {compact ? "GitHub" : "Continue with GitHub"}
-      </button>
-      <button className="oauth-btn" type="button">
-        <GoogleIcon aria-hidden className="oauth-icon" />
-        {compact ? "Google" : "Continue with Google"}
-      </button>
+      <div className="oauth-option">
+        <button
+          className="oauth-btn"
+          disabled={disabled}
+          onClick={() => onProviderSelect?.("github")}
+          type="button"
+        >
+          <GithubIcon aria-hidden className="oauth-icon" />
+          {providerLabel("github")}
+        </button>
+        {lastUsedProvider === "github" ? (
+          <div className="oauth-last-used">Last used</div>
+        ) : null}
+      </div>
+
+      <div className="oauth-option">
+        <button
+          className="oauth-btn"
+          disabled={disabled}
+          onClick={() => onProviderSelect?.("google")}
+          type="button"
+        >
+          <GoogleIcon aria-hidden className="oauth-icon" />
+          {providerLabel("google")}
+        </button>
+        {lastUsedProvider === "google" ? (
+          <div className="oauth-last-used">Last used</div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import type { ForgotPasswordErrors } from "@/features/auth/authTypes";
 import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
+import { ForgotPasswordIntro } from "@/features/auth/components/ForgotPasswordIntro";
 import { validateEmail } from "@/features/auth/lib/validation";
 import { sendPasswordResetEmail } from "@/features/auth/api/resetPasswordApi";
 
@@ -26,6 +27,7 @@ export function ForgotPasswordForm() {
     try {
       await sendPasswordResetEmail(email);
       setSent(true);
+      setEmail("");
     } catch (error) {
       setErrors({
         server:
@@ -62,7 +64,10 @@ export function ForgotPasswordForm() {
 
             <button
               className="btn btn-ghost"
-              onClick={() => setSent(false)}
+              onClick={() => {
+                setSent(false);
+                setErrors({});
+              }}
               type="button"
             >
               Send another email
@@ -77,6 +82,8 @@ export function ForgotPasswordForm() {
 
   return (
     <>
+      <ForgotPasswordIntro />
+
       {errors.server && <div className="form-alert">{errors.server}</div>}
 
       <form noValidate onSubmit={handleSubmit}>

--- a/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
@@ -1,24 +1,78 @@
-import type { SyntheticEvent } from 'react';
-import { useState } from 'react';
+import type { SyntheticEvent } from "react";
+import { useState } from "react";
 
-import type { ForgotPasswordErrors } from '@/features/auth/authTypes';
-import { AuthFooterLinks } from '@/features/auth/components/AuthFooterLinks';
-import { validateEmail } from '@/features/auth/lib/validation';
+import type { ForgotPasswordErrors } from "@/features/auth/authTypes";
+import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
+import { validateEmail } from "@/features/auth/lib/validation";
+import { sendPasswordResetEmail } from "@/features/auth/api/resetPasswordApi";
 
 export function ForgotPasswordForm() {
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState("");
   const [errors, setErrors] = useState<ForgotPasswordErrors>({});
   const [submitting, setSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     const emailError = validateEmail(email);
-    if (emailError) { setErrors({ email: emailError }); return; }
+    if (emailError) {
+      setErrors({ email: emailError });
+      return;
+    }
 
     setSubmitting(true);
     setErrors({});
-    // TODO: call password-reset API endpoint
-    // On success: render a confirmation view with the submitted email
+
+    try {
+      await sendPasswordResetEmail(email);
+      setSent(true);
+    } catch (error) {
+      setErrors({
+        server:
+          error instanceof Error ? error.message : "Unable to send reset link.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <>
+        <div className="auth-confirm">
+          <div aria-hidden="true" className="auth-confirm-mark">
+            OK
+          </div>
+
+          <div className="eyebrow mb-4">Check your email</div>
+
+          <h1>
+            Recovery link <em>sent</em>.
+          </h1>
+
+          <p className="lede">
+            If an account exists for that email, we sent a reset link. Check
+            your inbox and spam folder.
+          </p>
+
+          <div className="callback-actions">
+            <a className="btn btn-primary" href="/signin">
+              Back to sign in
+            </a>
+
+            <button
+              className="btn btn-ghost"
+              onClick={() => setSent(false)}
+              type="button"
+            >
+              Send another email
+            </button>
+          </div>
+        </div>
+
+        <AuthFooterLinks label="No account lookup · private by design" />
+      </>
+    );
   }
 
   return (
@@ -30,7 +84,7 @@ export function ForgotPasswordForm() {
           <label htmlFor="forgot-password-email">Email address</label>
           <input
             autoComplete="email"
-            className={errors.email ? 'is-error' : ''}
+            className={errors.email ? "is-error" : ""}
             id="forgot-password-email"
             onChange={(e) => {
               setEmail(e.target.value);
@@ -40,17 +94,26 @@ export function ForgotPasswordForm() {
             type="email"
             value={email}
           />
-          <span className="hint">We'll send a one-time reset link to this address.</span>
+          <span className="hint">
+            We'll send a one-time reset link to this address.
+          </span>
           {errors.email && <span className="field-error">{errors.email}</span>}
         </div>
 
-        <button className="btn btn-primary submit-btn mt-1" disabled={submitting} type="submit">
-          {submitting ? 'Sending…' : 'Send reset link →'}
+        <button
+          className="btn btn-primary submit-btn mt-1"
+          disabled={submitting}
+          type="submit"
+        >
+          {submitting ? "Sending…" : "Send reset link →"}
         </button>
       </form>
 
       <div className="alt-row">
-        Remembered it? <a className="link" href="/signin">Back to sign in</a>
+        Remembered it?{" "}
+        <a className="link" href="/signin">
+          Back to sign in
+        </a>
       </div>
 
       <AuthFooterLinks label="Link expires after 30 min" />

--- a/apps/web/src/features/auth/components/ResetPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ResetPasswordForm.tsx
@@ -1,0 +1,219 @@
+import type { ChangeEvent, SyntheticEvent } from "react";
+import { useEffect, useState } from "react";
+
+import type {
+  ResetPasswordErrors,
+  ResetPasswordFields,
+} from "@/features/auth/authTypes";
+import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
+import {
+  signOutAfterPasswordUpdate,
+  startPasswordRecoverySession,
+  updatePassword,
+} from "@/features/auth/api/resetPasswordApi";
+import {
+  passwordStrength,
+  strengthLabel,
+  validateNewPassword,
+} from "@/features/auth/lib/validation";
+
+export function ResetPasswordForm() {
+  const [fields, setFields] = useState<ResetPasswordFields>({
+    password: "",
+    confirmPassword: "",
+  });
+  const [errors, setErrors] = useState<ResetPasswordErrors>({});
+  const [isReady, setIsReady] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const strength = passwordStrength(fields.password);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function prepareRecoverySession() {
+      try {
+        await startPasswordRecoverySession();
+        if (isMounted) setIsReady(true);
+      } catch (error) {
+        if (!isMounted) return;
+        setErrors({
+          server:
+            error instanceof Error
+              ? error.message
+              : "We could not verify this reset link.",
+        });
+      }
+    }
+
+    prepareRecoverySession();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  function setField(field: keyof ResetPasswordFields) {
+    return (e: ChangeEvent<HTMLInputElement>) => {
+      setFields((prev) => ({ ...prev, [field]: e.target.value }));
+      if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }));
+    };
+  }
+
+  function validate(): ResetPasswordErrors {
+    const password = validateNewPassword(fields.password) ?? undefined;
+    const confirmPassword =
+      fields.confirmPassword !== fields.password
+        ? "Passwords must match."
+        : undefined;
+
+    return { password, confirmPassword };
+  }
+
+  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const nextErrors = validate();
+    if (nextErrors.password || nextErrors.confirmPassword) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    setSubmitting(true);
+    setErrors({});
+
+    try {
+      await updatePassword(fields.password);
+      await signOutAfterPasswordUpdate();
+      setIsComplete(true);
+    } catch (error) {
+      setErrors({
+        server:
+          error instanceof Error ? error.message : "Unable to update password.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (isComplete) {
+    return (
+      <>
+        <div className="auth-confirm">
+          <div aria-hidden="true" className="auth-confirm-mark">
+            OK
+          </div>
+
+          <div className="eyebrow mb-4">Password updated</div>
+
+          <h1>
+            You are ready to <em>sign in</em>.
+          </h1>
+
+          <p className="lede">
+            Your password was updated. Use the new password the next time you
+            sign in.
+          </p>
+
+          <div className="callback-actions">
+            <a className="btn btn-primary" href="/signin">
+              Go to sign in
+            </a>
+          </div>
+        </div>
+
+        <AuthFooterLinks label="Password updated securely" />
+      </>
+    );
+  }
+
+  if (!isReady) {
+    return (
+      <>
+        {errors.server ? (
+          <div className="form-alert">{errors.server}</div>
+        ) : (
+          <div className="callback-progress" aria-label="Loading">
+            <span />
+            <span />
+            <span />
+          </div>
+        )}
+
+        <div className="alt-row">
+          Need a new link?{" "}
+          <a className="link" href="/forgot-password">
+            Request another reset
+          </a>
+        </div>
+
+        <AuthFooterLinks label="Recovery links are one-time use" />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {errors.server && <div className="form-alert">{errors.server}</div>}
+
+      <form noValidate onSubmit={handleSubmit}>
+        <div className="field">
+          <label htmlFor="reset-password">New password</label>
+          <input
+            autoComplete="new-password"
+            className={errors.password ? "is-error" : ""}
+            id="reset-password"
+            onChange={setField("password")}
+            placeholder="At least 12 characters"
+            type="password"
+            value={fields.password}
+          />
+          {fields.password && (
+            <>
+              <div aria-hidden="true" className={`strength s-${strength}`}>
+                <i />
+                <i />
+                <i />
+                <i />
+              </div>
+              <span className="hint">
+                Strength: {strengthLabel(strength)}.
+                {strength < 3 ? " Try a passphrase." : " Nice."}
+              </span>
+            </>
+          )}
+          {errors.password && (
+            <span className="field-error">{errors.password}</span>
+          )}
+        </div>
+
+        <div className="field">
+          <label htmlFor="reset-password-confirm">Confirm password</label>
+          <input
+            autoComplete="new-password"
+            className={errors.confirmPassword ? "is-error" : ""}
+            id="reset-password-confirm"
+            onChange={setField("confirmPassword")}
+            placeholder="Type it once more"
+            type="password"
+            value={fields.confirmPassword}
+          />
+          {errors.confirmPassword && (
+            <span className="field-error">{errors.confirmPassword}</span>
+          )}
+        </div>
+
+        <button
+          className="btn btn-primary submit-btn"
+          disabled={submitting}
+          type="submit"
+        >
+          {submitting ? "Updating password..." : "Update password"}
+        </button>
+      </form>
+
+      <AuthFooterLinks label="Use a long, unique password" />
+    </>
+  );
+}

--- a/apps/web/src/features/auth/components/ResetPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ResetPasswordForm.tsx
@@ -6,6 +6,7 @@ import type {
   ResetPasswordFields,
 } from "@/features/auth/authTypes";
 import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
+import { ResetPasswordIntro } from "@/features/auth/components/ResetPasswordIntro";
 import {
   signOutAfterPasswordUpdate,
   startPasswordRecoverySession,
@@ -86,6 +87,10 @@ export function ResetPasswordForm() {
     try {
       await updatePassword(fields.password);
       await signOutAfterPasswordUpdate();
+      setFields({
+        password: "",
+        confirmPassword: "",
+      });
       setIsComplete(true);
     } catch (error) {
       setErrors({
@@ -155,6 +160,8 @@ export function ResetPasswordForm() {
 
   return (
     <>
+      <ResetPasswordIntro />
+
       {errors.server && <div className="form-alert">{errors.server}</div>}
 
       <form noValidate onSubmit={handleSubmit}>

--- a/apps/web/src/features/auth/components/ResetPasswordIntro.tsx
+++ b/apps/web/src/features/auth/components/ResetPasswordIntro.tsx
@@ -1,0 +1,14 @@
+export function ResetPasswordIntro() {
+  return (
+    <>
+      <div className="eyebrow mb-4">Set a new password</div>
+      <h1>
+        Choose a new <em>password</em>.
+      </h1>
+      <p className="lede">
+        Pick something long and unique. This will replace your old password
+        immediately.
+      </p>
+    </>
+  );
+}

--- a/apps/web/src/features/auth/components/ResetPasswordSidePanel.tsx
+++ b/apps/web/src/features/auth/components/ResetPasswordSidePanel.tsx
@@ -1,0 +1,41 @@
+export function ResetPasswordSidePanel() {
+  return (
+    <>
+      <div className="brand">
+        <span className="brand-mark">j</span>
+        <span>
+          jymb<span className="brand-dot">.</span>blog
+        </span>
+      </div>
+
+      <div className="side-reset">
+        <h2>
+          Fresh key, <em>same account</em>.
+        </h2>
+        <p>
+          We verified the recovery link. Set a new password, then sign in again
+          with the updated credentials.
+        </p>
+        <div className="side-steps">
+          <div className="side-step">
+            <span className="num">01</span>
+            <span>Use a password you have not used here before.</span>
+          </div>
+          <div className="side-step">
+            <span className="num">02</span>
+            <span>Confirm it so we can catch typing mistakes.</span>
+          </div>
+          <div className="side-step">
+            <span className="num">03</span>
+            <span>Return to sign in and open your account.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="side-meta">
+        <span>Password recovery</span>
+        <span>Supabase Auth</span>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/auth/components/SignInForm.tsx
+++ b/apps/web/src/features/auth/components/SignInForm.tsx
@@ -1,15 +1,49 @@
-import type { ChangeEvent, SyntheticEvent } from 'react';
-import { useState } from 'react';
+import type { ChangeEvent, SyntheticEvent } from "react";
+import { useEffect, useState } from "react";
 
-import type { SignInErrors, SignInFields } from '@/features/auth/authTypes';
-import { AuthFooterLinks } from '@/features/auth/components/AuthFooterLinks';
-import { AuthProviderButtons } from '@/features/auth/components/AuthProviderButtons';
-import { validateEmail, validatePassword } from '@/features/auth/lib/validation';
+import type {
+  SignInErrors,
+  SignInFields,
+  SocialAuthProvider,
+} from "@/features/auth/authTypes";
+import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
+import { AuthProviderButtons } from "@/features/auth/components/AuthProviderButtons";
+import { startSocialAuth } from "@/features/auth/api/registerApi";
+import { getSignedInUser, signInWithEmail } from "@/features/auth/api/signInApi";
+import {
+  validateEmail,
+  validatePassword,
+} from "@/features/auth/lib/validation";
 
 export function SignInForm() {
-  const [fields, setFields] = useState<SignInFields>({ email: '', password: '' });
+  const [fields, setFields] = useState<SignInFields>({
+    email: "",
+    password: "",
+  });
   const [errors, setErrors] = useState<SignInErrors>({});
   const [submitting, setSubmitting] = useState(false);
+  const [socialSubmitting, setSocialSubmitting] =
+    useState<SocialAuthProvider | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function redirectExistingSession() {
+      const currentUser = await getSignedInUser();
+
+      if (!isMounted || !currentUser) return;
+
+      window.location.href = currentUser.permissions.admin ? "/dashboard" : "/";
+    }
+
+    redirectExistingSession().catch(() => {
+      // Stay on sign in if the existing session cannot be resolved.
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   function set(field: keyof SignInFields) {
     return (e: ChangeEvent<HTMLInputElement>) => {
@@ -25,19 +59,61 @@ export function SignInForm() {
     };
   }
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     const errs = validate();
-    if (errs.email || errs.password) { setErrors(errs); return; }
+    if (errs.email || errs.password) {
+      setErrors(errs);
+      return;
+    }
 
     setSubmitting(true);
     setErrors({});
-    // TODO: call sign-in API endpoint
+
+    try {
+      const currentUser = await signInWithEmail({
+        email: fields.email,
+        password: fields.password,
+      });
+
+      if (currentUser.permissions.admin) {
+        window.location.href = "/dashboard";
+        return;
+      }
+
+      window.location.href = "/";
+    } catch (error) {
+      setErrors({
+        server: error instanceof Error ? error.message : "Unable to sign in.",
+      });
+      setSubmitting(false);
+    }
+  }
+
+  async function handleSocialSignIn(provider: SocialAuthProvider) {
+    setSocialSubmitting(provider);
+    setErrors({});
+
+    try {
+      await startSocialAuth(provider);
+    } catch (error) {
+      setErrors({
+        server:
+          error instanceof Error
+            ? error.message
+            : "Unable to start social sign in.",
+      });
+      setSocialSubmitting(null);
+    }
   }
 
   return (
     <>
-      <AuthProviderButtons />
+      <AuthProviderButtons
+        disabled={submitting || socialSubmitting !== null}
+        loadingProvider={socialSubmitting}
+        onProviderSelect={handleSocialSignIn}
+      />
 
       <div className="divider">or with email</div>
 
@@ -48,9 +124,9 @@ export function SignInForm() {
           <label htmlFor="signin-email">Email</label>
           <input
             autoComplete="email"
-            className={errors.email ? 'is-error' : ''}
+            className={errors.email ? "is-error" : ""}
             id="signin-email"
-            onChange={set('email')}
+            onChange={set("email")}
             placeholder="you@somewhere.com"
             type="email"
             value={fields.email}
@@ -64,14 +140,16 @@ export function SignInForm() {
           </label>
           <input
             autoComplete="current-password"
-            className={errors.password ? 'is-error' : ''}
+            className={errors.password ? "is-error" : ""}
             id="signin-password"
-            onChange={set('password')}
+            onChange={set("password")}
             placeholder="••••••••••••"
             type="password"
             value={fields.password}
           />
-          {errors.password && <span className="field-error">{errors.password}</span>}
+          {errors.password && (
+            <span className="field-error">{errors.password}</span>
+          )}
         </div>
 
         <label className="check-row">
@@ -79,14 +157,24 @@ export function SignInForm() {
           <span>Keep me signed in on this device</span>
         </label>
 
-        <button className="btn btn-primary submit-btn" disabled={submitting} type="submit">
-          {submitting ? 'Signing in…' : 'Sign in →'}
+        <button
+          className="btn btn-primary submit-btn"
+          disabled={submitting}
+          type="submit"
+        >
+          {submitting ? "Signing in…" : "Sign in →"}
         </button>
       </form>
 
       <div className="alt-row">
-        New here? <a className="link" href="/signup">Create an account</a> · or{' '}
-        <a className="link" href="/">read without signing in</a>
+        New here?{" "}
+        <a className="link" href="/signup">
+          Create an account
+        </a>{" "}
+        · or{" "}
+        <a className="link" href="/">
+          read without signing in
+        </a>
       </div>
 
       <AuthFooterLinks label="jymb.blog · auth v3.2" />

--- a/apps/web/src/features/auth/components/SignUpForm.tsx
+++ b/apps/web/src/features/auth/components/SignUpForm.tsx
@@ -24,6 +24,7 @@ import {
   registerWithEmail,
   startSocialAuth,
 } from "@/features/auth/api/registerApi";
+import { SignUpIntro } from "@/features/auth/components/SignUpIntro";
 
 export function SignUpForm() {
   const [fields, setFields] = useState<SignUpFields>({
@@ -94,6 +95,13 @@ export function SignUpForm() {
 
       if (result.needsEmailConfirmation || !result.currentUser) {
         setConfirmationMessage(getPendingSignupMessage());
+        setFields({
+          displayName: "",
+          handle: "",
+          email: "",
+          password: "",
+          terms: false,
+        });
         return;
       }
 
@@ -163,7 +171,10 @@ export function SignUpForm() {
 
             <button
               className="btn btn-ghost"
-              onClick={() => setConfirmationMessage(null)}
+              onClick={() => {
+                setConfirmationMessage(null);
+                setErrors({});
+              }}
               type="button"
             >
               Try another email
@@ -178,6 +189,8 @@ export function SignUpForm() {
 
   return (
     <>
+      <SignUpIntro />
+
       <AuthProviderButtons
         compact
         disabled={submitting || socialSubmitting !== null}

--- a/apps/web/src/features/auth/components/SignUpForm.tsx
+++ b/apps/web/src/features/auth/components/SignUpForm.tsx
@@ -1,7 +1,11 @@
 import type { SyntheticEvent } from "react";
 import { useState } from "react";
 
-import type { SignUpErrors, SignUpFields } from "@/features/auth/authTypes";
+import type {
+  SignUpErrors,
+  SignUpFields,
+  SocialAuthProvider,
+} from "@/features/auth/authTypes";
 import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
 import { AuthProviderButtons } from "@/features/auth/components/AuthProviderButtons";
 import {
@@ -12,7 +16,14 @@ import {
   validateHandle,
   validateNewPassword,
 } from "@/features/auth/lib/validation";
-import { registerWithEmail } from "@/features/auth/api/registerApi";
+import {
+  formatAuthProvider,
+  getLastAuthProvider,
+} from "@/features/auth/lib/lastAuthProvider";
+import {
+  registerWithEmail,
+  registerWithSocialProvider,
+} from "@/features/auth/api/registerApi";
 
 export function SignUpForm() {
   const [fields, setFields] = useState<SignUpFields>({
@@ -24,6 +35,11 @@ export function SignUpForm() {
   });
   const [errors, setErrors] = useState<SignUpErrors>({});
   const [submitting, setSubmitting] = useState(false);
+  const [socialSubmitting, setSocialSubmitting] =
+    useState<SocialAuthProvider | null>(null);
+  const [lastUsedProvider] = useState<SocialAuthProvider | null>(
+    getLastAuthProvider,
+  );
 
   const strength = passwordStrength(fields.password);
 
@@ -47,6 +63,14 @@ export function SignUpForm() {
     };
   }
 
+  function getPendingSignupMessage() {
+    if (lastUsedProvider) {
+      return `Almost there. A confirmation email may have been sent. If you do not see one, continue with ${formatAuthProvider(lastUsedProvider)}, your last used sign-in method.`;
+    }
+
+    return "Almost there. A confirmation email may have been sent, open it to finish creating your account.";
+  }
+
   async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     const errs = validate();
@@ -67,7 +91,7 @@ export function SignUpForm() {
 
       if (result.needsEmailConfirmation || !result.currentUser) {
         setErrors({
-          server: "Check your email to confirm your account, then sign in.",
+          server: getPendingSignupMessage(),
         });
         return;
       }
@@ -83,9 +107,32 @@ export function SignUpForm() {
     }
   }
 
+  async function handleSocialRegister(provider: SocialAuthProvider) {
+    setSocialSubmitting(provider);
+    setErrors({});
+
+    try {
+      await registerWithSocialProvider(provider);
+    } catch (error) {
+      setErrors({
+        server:
+          error instanceof Error
+            ? error.message
+            : "Unable to start social registration.",
+      });
+      setSocialSubmitting(null);
+    }
+  }
+
   return (
     <>
-      <AuthProviderButtons compact />
+      <AuthProviderButtons
+        compact
+        disabled={submitting || socialSubmitting !== null}
+        lastUsedProvider={lastUsedProvider}
+        loadingProvider={socialSubmitting}
+        onProviderSelect={handleSocialRegister}
+      />
 
       <div className="divider">or with email</div>
 

--- a/apps/web/src/features/auth/components/SignUpForm.tsx
+++ b/apps/web/src/features/auth/components/SignUpForm.tsx
@@ -37,6 +37,9 @@ export function SignUpForm() {
   const [submitting, setSubmitting] = useState(false);
   const [socialSubmitting, setSocialSubmitting] =
     useState<SocialAuthProvider | null>(null);
+  const [confirmationMessage, setConfirmationMessage] = useState<string | null>(
+    null,
+  );
   const [lastUsedProvider] = useState<SocialAuthProvider | null>(
     getLastAuthProvider,
   );
@@ -90,13 +93,11 @@ export function SignUpForm() {
       });
 
       if (result.needsEmailConfirmation || !result.currentUser) {
-        setErrors({
-          server: getPendingSignupMessage(),
-        });
+        setConfirmationMessage(getPendingSignupMessage());
         return;
       }
 
-      window.location.href = "/me";
+      window.location.href = "/";
     } catch (error) {
       setErrors({
         server:
@@ -122,6 +123,57 @@ export function SignUpForm() {
       });
       setSocialSubmitting(null);
     }
+  }
+
+  if (confirmationMessage) {
+    return (
+      <>
+        <div className="auth-confirm">
+          <div aria-hidden="true" className="auth-confirm-mark">
+            OK
+          </div>
+
+          <div className="eyebrow mb-4">Email confirmation</div>
+
+          <h1>
+            Check your <em>email</em>.
+          </h1>
+
+          <p className="lede">{confirmationMessage}</p>
+
+          {errors.server && <div className="form-alert">{errors.server}</div>}
+
+          <div className="callback-actions">
+            {lastUsedProvider ? (
+              <button
+                className="btn btn-primary"
+                disabled={socialSubmitting !== null}
+                onClick={() => handleSocialRegister(lastUsedProvider)}
+                type="button"
+              >
+                {socialSubmitting === lastUsedProvider
+                  ? `Opening ${formatAuthProvider(lastUsedProvider)}...`
+                  : `Continue with ${formatAuthProvider(lastUsedProvider)}`}
+              </button>
+            ) : (
+              <a className="btn btn-primary" href="/signin">
+                Back to sign in
+              </a>
+            )}
+
+            <button
+              className="btn btn-ghost"
+              onClick={() => setConfirmationMessage(null)}
+              type="button"
+            >
+              Try another email
+            </button>
+          </div>
+        </div>
+
+        <AuthFooterLinks label="No tracking pixels · no third-party scripts" />
+      </>
+    );
   }
 
   return (

--- a/apps/web/src/features/auth/components/SignUpForm.tsx
+++ b/apps/web/src/features/auth/components/SignUpForm.tsx
@@ -1,9 +1,9 @@
-import type { SyntheticEvent } from 'react';
-import { useState } from 'react';
+import type { SyntheticEvent } from "react";
+import { useState } from "react";
 
-import type { SignUpErrors, SignUpFields } from '@/features/auth/authTypes';
-import { AuthFooterLinks } from '@/features/auth/components/AuthFooterLinks';
-import { AuthProviderButtons } from '@/features/auth/components/AuthProviderButtons';
+import type { SignUpErrors, SignUpFields } from "@/features/auth/authTypes";
+import { AuthFooterLinks } from "@/features/auth/components/AuthFooterLinks";
+import { AuthProviderButtons } from "@/features/auth/components/AuthProviderButtons";
 import {
   passwordStrength,
   strengthLabel,
@@ -11,14 +11,15 @@ import {
   validateEmail,
   validateHandle,
   validateNewPassword,
-} from '@/features/auth/lib/validation';
+} from "@/features/auth/lib/validation";
+import { registerWithEmail } from "@/features/auth/api/registerApi";
 
 export function SignUpForm() {
   const [fields, setFields] = useState<SignUpFields>({
-    displayName: '',
-    handle: '',
-    email: '',
-    password: '',
+    displayName: "",
+    handle: "",
+    email: "",
+    password: "",
     terms: false,
   });
   const [errors, setErrors] = useState<SignUpErrors>({});
@@ -26,7 +27,10 @@ export function SignUpForm() {
 
   const strength = passwordStrength(fields.password);
 
-  function setField<K extends keyof SignUpFields>(field: K, value: SignUpFields[K]) {
+  function setField<K extends keyof SignUpFields>(
+    field: K,
+    value: SignUpFields[K],
+  ) {
     setFields((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }));
   }
@@ -37,18 +41,46 @@ export function SignUpForm() {
       handle: validateHandle(fields.handle) ?? undefined,
       email: validateEmail(fields.email) ?? undefined,
       password: validateNewPassword(fields.password) ?? undefined,
-      terms: !fields.terms ? 'You must accept the guidelines to continue.' : undefined,
+      terms: !fields.terms
+        ? "You must accept the guidelines to continue."
+        : undefined,
     };
   }
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     const errs = validate();
-    if (Object.values(errs).some(Boolean)) { setErrors(errs); return; }
+    if (Object.values(errs).some(Boolean)) {
+      setErrors(errs);
+      return;
+    }
 
     setSubmitting(true);
     setErrors({});
-    // TODO: call sign-up API endpoint
+    try {
+      const result = await registerWithEmail({
+        displayName: fields.displayName,
+        handle: fields.handle,
+        email: fields.email,
+        password: fields.password,
+      });
+
+      if (result.needsEmailConfirmation || !result.currentUser) {
+        setErrors({
+          server: "Check your email to confirm your account, then sign in.",
+        });
+        return;
+      }
+
+      window.location.href = "/me";
+    } catch (error) {
+      setErrors({
+        server:
+          error instanceof Error ? error.message : "Unable to create account.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (
@@ -65,28 +97,32 @@ export function SignUpForm() {
             <label htmlFor="signup-display-name">Display name</label>
             <input
               autoComplete="name"
-              className={errors.displayName ? 'is-error' : ''}
+              className={errors.displayName ? "is-error" : ""}
               id="signup-display-name"
-              onChange={(e) => setField('displayName', e.target.value)}
+              onChange={(e) => setField("displayName", e.target.value)}
               placeholder="Hannah"
               type="text"
               value={fields.displayName}
             />
-            {errors.displayName && <span className="field-error">{errors.displayName}</span>}
+            {errors.displayName && (
+              <span className="field-error">{errors.displayName}</span>
+            )}
           </div>
 
           <div className="field">
             <label htmlFor="signup-handle">Handle</label>
             <input
               autoComplete="username"
-              className={errors.handle ? 'is-error' : ''}
+              className={errors.handle ? "is-error" : ""}
               id="signup-handle"
-              onChange={(e) => setField('handle', e.target.value)}
+              onChange={(e) => setField("handle", e.target.value)}
               placeholder="@hannah_d"
               type="text"
               value={fields.handle}
             />
-            {errors.handle && <span className="field-error">{errors.handle}</span>}
+            {errors.handle && (
+              <span className="field-error">{errors.handle}</span>
+            )}
           </div>
         </div>
 
@@ -94,14 +130,16 @@ export function SignUpForm() {
           <label htmlFor="signup-email">Email</label>
           <input
             autoComplete="email"
-            className={errors.email ? 'is-error' : ''}
+            className={errors.email ? "is-error" : ""}
             id="signup-email"
-            onChange={(e) => setField('email', e.target.value)}
+            onChange={(e) => setField("email", e.target.value)}
             placeholder="you@somewhere.com"
             type="email"
             value={fields.email}
           />
-          <span className="hint">Used only for confirmation + reply notifications.</span>
+          <span className="hint">
+            Used only for confirmation + reply notifications.
+          </span>
           {errors.email && <span className="field-error">{errors.email}</span>}
         </div>
 
@@ -109,9 +147,9 @@ export function SignUpForm() {
           <label htmlFor="signup-password">Password</label>
           <input
             autoComplete="new-password"
-            className={errors.password ? 'is-error' : ''}
+            className={errors.password ? "is-error" : ""}
             id="signup-password"
-            onChange={(e) => setField('password', e.target.value)}
+            onChange={(e) => setField("password", e.target.value)}
             placeholder="At least 12 characters"
             type="password"
             value={fields.password}
@@ -119,25 +157,32 @@ export function SignUpForm() {
           {fields.password && (
             <>
               <div aria-hidden="true" className={`strength s-${strength}`}>
-                <i /><i /><i /><i />
+                <i />
+                <i />
+                <i />
+                <i />
               </div>
               <span className="hint">
-                Strength: {strengthLabel(strength)}.{strength < 3 ? ' Try a passphrase.' : ' Nice.'}
+                Strength: {strengthLabel(strength)}.
+                {strength < 3 ? " Try a passphrase." : " Nice."}
               </span>
             </>
           )}
-          {errors.password && <span className="field-error">{errors.password}</span>}
+          {errors.password && (
+            <span className="field-error">{errors.password}</span>
+          )}
         </div>
 
         <label className="check-row">
           <input
             checked={fields.terms}
-            onChange={(e) => setField('terms', e.target.checked)}
+            onChange={(e) => setField("terms", e.target.checked)}
             type="checkbox"
           />
           <span>
-            I've read and accept the <a href="#">community guidelines</a> and{' '}
-            <a href="#">privacy notice</a>. Be kind in the comments — that's the whole policy.
+            I've read and accept the <a href="#">community guidelines</a> and{" "}
+            <a href="#">privacy notice</a>. Be kind in the comments — that's the
+            whole policy.
           </span>
         </label>
         {errors.terms && <span className="field-error">{errors.terms}</span>}
@@ -145,18 +190,25 @@ export function SignUpForm() {
         <label className="check-row">
           <input type="checkbox" />
           <span>
-            Also subscribe me to new essays via email (you can also do this on the{' '}
-            <a href="/subscribe">subscribe page</a>).
+            Also subscribe me to new essays via email (you can also do this on
+            the <a href="/subscribe">subscribe page</a>).
           </span>
         </label>
 
-        <button className="btn btn-primary submit-btn" disabled={submitting} type="submit">
-          {submitting ? 'Creating account…' : 'Create account →'}
+        <button
+          className="btn btn-primary submit-btn"
+          disabled={submitting}
+          type="submit"
+        >
+          {submitting ? "Creating account…" : "Create account →"}
         </button>
       </form>
 
       <div className="alt-row">
-        Already have one? <a className="link" href="/signin">Sign in</a>
+        Already have one?{" "}
+        <a className="link" href="/signin">
+          Sign in
+        </a>
       </div>
 
       <AuthFooterLinks label="No tracking pixels · no third-party scripts" />

--- a/apps/web/src/features/auth/components/SignUpForm.tsx
+++ b/apps/web/src/features/auth/components/SignUpForm.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/features/auth/lib/lastAuthProvider";
 import {
   registerWithEmail,
-  registerWithSocialProvider,
+  startSocialAuth,
 } from "@/features/auth/api/registerApi";
 
 export function SignUpForm() {
@@ -113,7 +113,7 @@ export function SignUpForm() {
     setErrors({});
 
     try {
-      await registerWithSocialProvider(provider);
+      await startSocialAuth(provider);
     } catch (error) {
       setErrors({
         server:

--- a/apps/web/src/features/auth/lib/lastAuthProvider.ts
+++ b/apps/web/src/features/auth/lib/lastAuthProvider.ts
@@ -1,0 +1,45 @@
+import type { SocialAuthProvider } from "@/features/auth/authTypes";
+
+const lastAuthProviderKey = "last-auth-provider";
+const pendingAuthProviderKey = "pending-auth-provider";
+
+const providerLabels: Record<SocialAuthProvider, string> = {
+  github: "GitHub",
+  google: "Google",
+};
+
+export function getLastAuthProvider(): SocialAuthProvider | null {
+  if (typeof window === "undefined") return null;
+
+  const storedProvider = window.localStorage.getItem(lastAuthProviderKey);
+
+  return storedProvider === "github" || storedProvider === "google"
+    ? storedProvider
+    : null;
+}
+
+export function setLastAuthProvider(provider: SocialAuthProvider): void {
+  window.localStorage.setItem(lastAuthProviderKey, provider);
+}
+
+export function getPendingAuthProvider(): SocialAuthProvider | null {
+  if (typeof window === "undefined") return null;
+
+  const storedProvider = window.sessionStorage.getItem(pendingAuthProviderKey);
+
+  return storedProvider === "github" || storedProvider === "google"
+    ? storedProvider
+    : null;
+}
+
+export function setPendingAuthProvider(provider: SocialAuthProvider): void {
+  window.sessionStorage.setItem(pendingAuthProviderKey, provider);
+}
+
+export function clearPendingAuthProvider(): void {
+  window.sessionStorage.removeItem(pendingAuthProviderKey);
+}
+
+export function formatAuthProvider(provider: SocialAuthProvider): string {
+  return providerLabels[provider];
+}

--- a/apps/web/src/lib/auth/supabaseClient.ts
+++ b/apps/web/src/lib/auth/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+    import.meta.env.VITE_SUPABASE_URL,
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY,
+);

--- a/apps/web/src/lib/theme/useThemeMode.ts
+++ b/apps/web/src/lib/theme/useThemeMode.ts
@@ -1,16 +1,21 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { ThemeMode } from "@/lib/theme/themeTypes";
 
 const themeModeStorageKey = "theme-mode";
 
 function getInitialTheme(): ThemeMode {
-  if (typeof document === "undefined") return "light";
-  return document.documentElement.dataset.mode === "dark" ? "dark" : "light";
+  return "light";
 }
 
 export function useThemeMode() {
   const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialTheme);
+
+  useEffect(() => {
+    setThemeMode(
+      document.documentElement.dataset.mode === "dark" ? "dark" : "light",
+    );
+  }, []);
 
   function toggleThemeMode() {
     const nextTheme = themeMode === "dark" ? "light" : "dark";

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -578,6 +578,12 @@
     grid-template-columns: 1fr 1fr;
   }
 
+  .oauth-option {
+    display: grid;
+    gap: 0;
+    grid-template-rows: auto 18px;
+  }
+
   .oauth-btn {
     display: flex;
     align-items: center;
@@ -592,12 +598,14 @@
     font-weight: 500;
     color: var(--ink-2);
     transition: all 0.15s;
+    min-height: 43px;
   }
 
   .oauth-btns-compact .oauth-btn {
     gap: 8px;
     padding: 10px 12px;
     font-size: 13px;
+    min-height: 41px;
   }
 
   .oauth-btns-compact .oauth-icon {
@@ -608,6 +616,23 @@
   .oauth-btn:hover {
     background: var(--paper-2);
     border-color: var(--ink-4);
+  }
+
+  .oauth-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.72;
+  }
+
+  .oauth-last-used {
+    display: grid;
+    place-items: center;
+    min-height: 18px;
+    background: var(--accent);
+    color: white;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
   }
 
   .oauth-icon {

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -843,6 +843,27 @@
     justify-items: start;
   }
 
+  .auth-confirm {
+    display: grid;
+    justify-items: start;
+  }
+
+  .auth-confirm-mark {
+    display: grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    margin-bottom: 22px;
+    border: 1px solid var(--rule);
+    border-radius: 50%;
+    background: color-mix(in oklab, var(--accent) 14%, transparent);
+    color: var(--accent-ink);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+
   .callback-mark {
     display: grid;
     place-items: center;

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -813,6 +813,90 @@
     color: var(--ink);
   }
 
+  .auth-callback {
+    display: grid;
+    justify-items: start;
+  }
+
+  .callback-mark {
+    display: grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    margin-bottom: 22px;
+    border: 1px solid var(--rule);
+    border-radius: 50%;
+    color: var(--accent-ink);
+    font-family: var(--font-mono);
+    font-size: 18px;
+    font-weight: 700;
+  }
+
+  .callback-mark.is-loading {
+    border-top-color: var(--accent);
+    animation: callback-spin 900ms linear infinite;
+  }
+
+  .callback-mark.is-error {
+    border-color: oklch(0.55 0.18 25);
+    background: oklch(0.96 0.04 25);
+    color: oklch(0.42 0.18 25);
+  }
+
+  :root[data-mode="dark"] .callback-mark.is-error {
+    background: oklch(0.22 0.06 25);
+    color: oklch(0.78 0.12 25);
+    border-color: oklch(0.38 0.12 25);
+  }
+
+  .callback-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 6px;
+  }
+
+  .callback-progress {
+    display: flex;
+    gap: 6px;
+    margin-top: 4px;
+  }
+
+  .callback-progress span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: callback-pulse 900ms ease-in-out infinite;
+  }
+
+  .callback-progress span:nth-child(2) {
+    animation-delay: 120ms;
+  }
+
+  .callback-progress span:nth-child(3) {
+    animation-delay: 240ms;
+  }
+
+  @keyframes callback-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes callback-pulse {
+    0%,
+    100% {
+      opacity: 0.3;
+      transform: translateY(0);
+    }
+
+    50% {
+      opacity: 1;
+      transform: translateY(-3px);
+    }
+  }
+
   .auth-side {
     background: #15161a;
     color: #fafaf7;

--- a/docs/architecture/auth-authorization.md
+++ b/docs/architecture/auth-authorization.md
@@ -13,11 +13,13 @@ This document defines the target frontend authentication and authorization struc
 ```text
 1. Frontend auth UI foundation     done
 2. Backend/Supabase auth setup     done
-3. Frontend auth wiring            next
+3. Frontend auth wiring            done for signup/signin/password recovery
 4. Authorization guards/roles      partially started
 ```
 
 Backend/Supabase setup currently includes the `auth:api` guard, Supabase bearer-token verification through JWKS, local `users.supabase_user_id` mapping, `GET /api/v1/me`, CORS config, JSON `401` behavior for API routes, and the initial admin middleware/role helpers.
+
+Frontend auth wiring currently includes email signup, email confirmation callback handling, Google/GitHub social auth, email/password signin, existing-session signin redirects, last-used social provider hints, forgot-password email requests, and reset-password completion through Supabase Auth.
 
 ## Backend Auth Implementation
 
@@ -39,7 +41,8 @@ GET /api/v1/me
             └── read Authorization: Bearer <token>
                 └── SupabaseTokenVerifier verifies token through JWKS
                     └── claims.sub maps to users.supabase_user_id
-                        └── User::firstOrCreate resolves local app user
+                        └── existing user is resolved by Supabase id or email
+                            └── missing local profile fields are synced
                             └── CurrentUserController reads $request->user()
 ```
 
@@ -52,6 +55,8 @@ Valid token   -> guard returns User -> controller runs
 ```
 
 Supabase Auth remains the identity source. Laravel does not store passwords or implement password login/register for this rebuild. Laravel stores the local app user record, role, profile metadata, and future relationships such as post authorship.
+
+Local users include a unique `handle`. Email signup sends the requested handle in Supabase metadata. Social signup/signin generates a local handle from provider metadata or email when one is missing; users can change this later from the account profile flow.
 
 ```text
 Supabase Auth user id
@@ -73,7 +78,9 @@ apps/web
 │   ├── /profile/:username
 │   ├── /signin
 │   ├── /signup
-│   └── /forgot-password
+│   ├── /forgot-password
+│   ├── /reset-password
+│   └── /auth/callback
 │
 ├── User account area
 │   ├── /me
@@ -119,13 +126,85 @@ Admin
 
 ```text
 /signin
-└── Supabase signin
-    └── frontend receives auth session/token
-        └── call Laravel: GET /api/v1/me
-            ├── role: admin -> redirect /dashboard
-            ├── role: user + returnUrl -> redirect back
-            └── role: user no returnUrl -> redirect /me
+├── Email/password signin
+│   └── Supabase signInWithPassword
+│       └── frontend receives auth session/token
+│           └── call Laravel: GET /api/v1/me
+│               ├── role: admin -> redirect /dashboard
+│               └── role: user -> redirect /
+│
+├── Existing Supabase session
+│   └── call Laravel: GET /api/v1/me
+│       ├── role: admin -> redirect /dashboard
+│       └── role: user -> redirect /
+│
+└── Google/GitHub social signin
+    └── Supabase OAuth redirects to /auth/callback
+        └── callback silently exchanges provider code/token
+            └── call Laravel: GET /api/v1/me
+                ├── role: admin -> redirect /dashboard
+                └── role: user -> redirect /
 ```
+
+The `/auth/callback` route is user-visible for email confirmation and error states. Normal social signin/signup provider callbacks are processed silently and redirected immediately.
+
+## Signup Flow
+
+```text
+/signup
+├── Email/password signup
+│   └── Supabase signUp with display_name and handle metadata
+│       ├── no session -> show email confirmation state
+│       └── session -> call Laravel: GET /api/v1/me -> redirect /
+│
+└── Google/GitHub social signup
+    └── Supabase OAuth redirects to /auth/callback
+        └── callback exchanges provider code/token
+            └── call Laravel: GET /api/v1/me
+                ├── create/sync local user
+                ├── remember last used provider
+                ├── role: admin -> redirect /dashboard
+                └── role: user -> redirect /
+```
+
+Email confirmation links also return to `/auth/callback`, which restores the Supabase session, syncs the local Laravel user, and redirects by role.
+
+## Password Recovery Flow
+
+Password recovery is Supabase-owned and does not use a Laravel password reset endpoint.
+
+```text
+/forgot-password
+└── Supabase resetPasswordForEmail
+    └── redirectTo: <frontend origin>/reset-password
+        └── show neutral "check your email" confirmation state
+
+/reset-password
+└── restore Supabase recovery session from ?code=... or #access_token=...
+    └── user enters new password and confirmation
+        └── Supabase updateUser({ password })
+            └── sign out after password update
+                └── show success state with link to /signin
+```
+
+Recovery UI must not reveal whether an email address exists. Use neutral copy such as:
+
+```text
+If an account exists for that email, we sent a reset link.
+```
+
+Supabase dashboard configuration must allow these frontend redirect URLs during local development:
+
+```text
+http://localhost:3000/auth/callback
+http://localhost:3000/reset-password
+```
+
+Production should add the matching HTTPS URLs. Auth emails are sent through Supabase Auth. When using Mailtrap or another SMTP provider, configure custom SMTP in Supabase, not Laravel.
+
+## Current Account Redirect Note
+
+The target account area includes `/me`, but the current frontend implementation redirects normal authenticated users to `/` until the account overview screen exists. Admin users redirect to `/dashboard`.
 
 ## Frontend Folder Structure
 
@@ -212,7 +291,7 @@ flowchart TD
   C --> C2["Blog List"]
   C --> C3["Blog Detail"]
   C --> C4["Public Profile"]
-  C --> C5["Signin / Signup / Forgot Password"]
+  C --> C5["Signin / Signup / Forgot Password / Reset Password"]
 
   C3 --> H{"Wants to Comment?"}
   H -->|Guest| I["Redirect to /signin"]
@@ -221,6 +300,10 @@ flowchart TD
   I --> K["Central Signin Form"]
   K --> L["Supabase Auth"]
   L --> D
+
+  C5 --> P["Supabase Auth Emails"]
+  P --> Q["/auth/callback or /reset-password"]
+  Q --> D
 
   F --> F1["/me Overview"]
   F --> F2["/me/profile"]
@@ -247,3 +330,8 @@ flowchart TD
 - Normal users cannot access `/dashboard`.
 - Admin users can access `/dashboard` from the same signin flow.
 - Admin-only API calls are rejected unless `GET /api/v1/me` resolves an admin role.
+- Email signup can request a handle and sync a local user after confirmation.
+- Google/GitHub signup and signin create or sync the same local Laravel user.
+- Email/password signin redirects normal users to `/` and admins to `/dashboard`.
+- Forgot-password requests do not reveal whether the email exists.
+- Reset-password links land on `/reset-password`, update the Supabase password, sign out, and return the user to signin.


### PR DESCRIPTION
## Summary

Wires frontend authentication flows to Supabase Auth and the Laravel API, including email signup/signin, social auth, auth callbacks, password recovery, and local user profile syncing.

## Key Changes

- Adds the Supabase web client and auth API helpers for signup, signin, current-user lookup, OAuth, and password reset.
- Connects signup to Supabase email registration with display name and handle metadata.
- Adds email confirmation handling through `/auth/callback`.
- Wires Google/GitHub social auth with callback session exchange and last-used provider hints.
- Wires email/password signin and existing-session redirects.
- Adds forgot-password and reset-password flows using Supabase recovery links.
- Updates Laravel auth user syncing to support handles, provider metadata, avatars, and existing-user matching.
- Adds a nullable unique `handle` column to users.
- Updates auth architecture documentation for the implemented Supabase/Laravel flow.
- Includes UI polish for auth forms, callback states, reset screens, and theme hydration sync.

## Notes

- Laravel remains responsible for resolving Supabase JWTs into local users and roles.
- Supabase owns password authentication, OAuth, confirmation emails, and password recovery.
- The current branch still uses the existing current-user endpoint shape from the implemented code; later route-contract changes like replacing `/me` with `/session` should be handled separately unless included in this PR.

## Verification

- Reviewed branch commits and diff against `main`.
- Frontend typecheck previously passed with `npm run typecheck`.
- Backend automated tests were not run in this pass.
