### PR TITLE
Frontend profile UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ docs/*
 !docs/architecture/
 docs/architecture/*
 !docs/architecture/auth-authorization.md
+!docs/architecture/profile-page.md
 !docs/setup/
 docs/setup/*
 !docs/setup/frontend-structure.md

--- a/apps/api/app/Http/Resources/SessionResource.php
+++ b/apps/api/app/Http/Resources/SessionResource.php
@@ -18,6 +18,7 @@ class SessionResource extends JsonResource
                 'display_name' => $this->display_name,
                 'avatar_url' => $this->avatar_url,
                 'role' => $this->role,
+                'created_at' => $this->created_at?->toISOString(),
             ],
             'permissions' => app(UserPermissionService::class)->permissionsFor($this->resource),
         ];

--- a/apps/web/pages/(user)/profile/+Page.tsx
+++ b/apps/web/pages/(user)/profile/+Page.tsx
@@ -1,4 +1,27 @@
-import { ProfilePage } from "@/features/profile/components/ProfilePage";
+import { ProfileCommentHistory } from '@/features/profile/components/ProfileCommentHistory';
+import { ProfileDangerZone } from '@/features/profile/components/ProfileDangerZone';
+import { ProfileHead } from '@/features/profile/components/ProfileHead';
+import { ProfilePasswordSection } from '@/features/profile/components/ProfilePasswordSection';
+import { ProfilePage } from '@/features/profile/components/ProfilePage';
+import { ProfileRecentlyViewed } from '@/features/profile/components/ProfileRecentlyViewed';
+import { ProfileSidebar } from '@/features/profile/components/ProfileSidebar';
+
 export default function Page() {
-  return <ProfilePage />;
+  return (
+    <>
+      <ProfileHead />
+
+      <div className="shell profile-layout">
+        <div>
+          <ProfilePage />
+          <ProfilePasswordSection />
+          <ProfileCommentHistory />
+          <ProfileRecentlyViewed />
+          <ProfileDangerZone />
+        </div>
+
+        <ProfileSidebar />
+      </div>
+    </>
+  );
 }

--- a/apps/web/src/features/auth/authTypes.ts
+++ b/apps/web/src/features/auth/authTypes.ts
@@ -53,6 +53,7 @@ export type SessionUser = {
   display_name: string | null;
   avatar_url: string | null;
   role: string;
+  created_at: string | null;
 };
 
 export type UserPermissions = {

--- a/apps/web/src/features/profile/components/ProfileCommentHistory.tsx
+++ b/apps/web/src/features/profile/components/ProfileCommentHistory.tsx
@@ -1,0 +1,10 @@
+export function ProfileCommentHistory() {
+  return (
+    <div className="profile-section">
+      <h2>Comment history</h2>
+      <p style={{ fontSize: '14px', color: 'var(--ink-4)', margin: 0 }}>
+        No comments yet. Join the conversation on any post.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/profile/components/ProfileDangerZone.tsx
+++ b/apps/web/src/features/profile/components/ProfileDangerZone.tsx
@@ -1,0 +1,19 @@
+export function ProfileDangerZone() {
+  return (
+    <div className="danger-section">
+      <h2>Delete account</h2>
+      <p>
+        Permanently removes your account, comment history, and reading data. This cannot be undone.
+        Your comments on public posts will be anonymised.
+      </p>
+      <button
+        className="btn btn-sm"
+        disabled
+        style={{ borderColor: 'oklch(0.65 0.14 20)', color: 'oklch(0.42 0.14 20)', opacity: 0.5, cursor: 'not-allowed' }}
+        type="button"
+      >
+        Delete my account
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/profile/components/ProfileForm.tsx
+++ b/apps/web/src/features/profile/components/ProfileForm.tsx
@@ -1,9 +1,6 @@
-import type { ChangeEvent, FormEvent } from "react";
+import type { ChangeEvent, FormEvent } from 'react';
 
-import type {
-  ProfileFormFields,
-  ProfileFormProps,
-} from "@/features/profile/profileTypes";
+import type { ProfileFormFields, ProfileFormProps } from '@/features/profile/profileTypes';
 
 export function ProfileForm({
   errors,
@@ -26,109 +23,81 @@ export function ProfileForm({
   }
 
   return (
-    <form className="card grid gap-5" noValidate onSubmit={handleSubmit}>
-      <div>
-        <p className="eyebrow mb-2">Private profile</p>
-        <h1>Profile</h1>
-        <p className="text-muted">
-          Update the account details that are safe to sync with your public
-          profile.
-        </p>
+    <form noValidate onSubmit={handleSubmit}>
+      <h2>Account</h2>
+
+      {errors.server && <div className="form-alert">{errors.server}</div>}
+      {successMessage && <div className="form-alert">{successMessage}</div>}
+
+      <div className="field">
+        <label htmlFor="profile-display-name">Display name</label>
+        <input
+          className={errors.display_name ? 'is-error' : ''}
+          id="profile-display-name"
+          onChange={set('display_name')}
+          placeholder="Your display name"
+          type="text"
+          value={fields.display_name}
+        />
+        {errors.display_name && <span className="field-error">{errors.display_name}</span>}
       </div>
 
-      {errors.server ? <div className="form-alert">{errors.server}</div> : null}
-      {successMessage ? <div className="form-alert">{successMessage}</div> : null}
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="field">
-          <label htmlFor="profile-display-name">Display name</label>
-          <input
-            className={errors.display_name ? "is-error" : ""}
-            id="profile-display-name"
-            onChange={set("display_name")}
-            placeholder="Your display name"
-            type="text"
-            value={fields.display_name}
-          />
-          {errors.display_name ? (
-            <span className="field-error">{errors.display_name}</span>
-          ) : null}
-        </div>
-
-        <div className="field">
-          <label htmlFor="profile-avatar-url">Avatar URL</label>
-          <input
-            className={errors.avatar_url ? "is-error" : ""}
-            id="profile-avatar-url"
-            onChange={set("avatar_url")}
-            placeholder="https://example.com/avatar.jpg"
-            type="url"
-            value={fields.avatar_url}
-          />
-          {errors.avatar_url ? (
-            <span className="field-error">{errors.avatar_url}</span>
-          ) : null}
-        </div>
-
+      <div className="field-row">
         <div className="field">
           <label htmlFor="profile-first-name">First name</label>
           <input
-            className={errors.first_name ? "is-error" : ""}
+            className={errors.first_name ? 'is-error' : ''}
             id="profile-first-name"
-            onChange={set("first_name")}
+            onChange={set('first_name')}
             placeholder="First name"
             type="text"
             value={fields.first_name}
           />
-          {errors.first_name ? (
-            <span className="field-error">{errors.first_name}</span>
-          ) : null}
+          {errors.first_name && <span className="field-error">{errors.first_name}</span>}
         </div>
 
         <div className="field">
           <label htmlFor="profile-last-name">Last name</label>
           <input
-            className={errors.last_name ? "is-error" : ""}
+            className={errors.last_name ? 'is-error' : ''}
             id="profile-last-name"
-            onChange={set("last_name")}
+            onChange={set('last_name')}
             placeholder="Last name"
             type="text"
             value={fields.last_name}
           />
-          {errors.last_name ? (
-            <span className="field-error">{errors.last_name}</span>
-          ) : null}
+          {errors.last_name && <span className="field-error">{errors.last_name}</span>}
         </div>
       </div>
 
-      <div className="grid gap-3 border-t border-rule pt-4 text-sm md:grid-cols-2">
-        <ProfileMeta label="Email" value={profile.email} />
-        <ProfileMeta label="Handle" value={profile.handle} />
-        <ProfileMeta label="Role" value={profile.role} />
-        <ProfileMeta
-          label="Joined"
-          value={
-            profile.created_at
-              ? new Date(profile.created_at).toLocaleDateString()
-              : "Not available"
-          }
+      <div className="field">
+        <label htmlFor="profile-avatar-url">Avatar URL</label>
+        <input
+          className={errors.avatar_url ? 'is-error' : ''}
+          id="profile-avatar-url"
+          onChange={set('avatar_url')}
+          placeholder="https://example.com/avatar.jpg"
+          type="url"
+          value={fields.avatar_url}
         />
+        {errors.avatar_url && <span className="field-error">{errors.avatar_url}</span>}
       </div>
 
-      <div>
-        <button className="btn btn-primary" disabled={isSubmitting} type="submit">
-          {isSubmitting ? "Saving..." : "Save profile"}
-        </button>
+      <div className="field">
+        <label htmlFor="profile-email">Email address</label>
+        <input
+          id="profile-email"
+          readOnly
+          style={{ opacity: 0.6, cursor: 'default' }}
+          type="email"
+          value={profile.email}
+        />
+        <span className="hint">Used for sign-in and notifications. Never shown publicly.</span>
       </div>
+
+      <button className="btn btn-primary" disabled={isSubmitting} type="submit">
+        {isSubmitting ? 'Saving…' : 'Save changes'}
+      </button>
     </form>
-  );
-}
-
-function ProfileMeta({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <div className="text-xs uppercase text-muted">{label}</div>
-      <div className="mt-1 font-medium text-ink">{value}</div>
-    </div>
   );
 }

--- a/apps/web/src/features/profile/components/ProfileHead.tsx
+++ b/apps/web/src/features/profile/components/ProfileHead.tsx
@@ -1,0 +1,41 @@
+import { useCurrentSession } from '@/features/auth/session';
+
+export function ProfileHead() {
+  const { user } = useCurrentSession();
+
+  const displayName = user?.display_name ?? user?.handle?.replace(/^@/, '') ?? 'User';
+  const handle = user?.handle ?? '';
+  const avatarInitial = displayName.charAt(0).toUpperCase();
+  const memberSince = user?.created_at
+    ? new Date(user.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+    : null;
+
+  const metaItems = [
+    handle || null,
+    memberSince ? `Member since ${memberSince}` : null,
+  ].filter(Boolean);
+
+  return (
+    <div className="shell">
+      <div className="profile-head">
+        {user?.avatar_url ? (
+          <img alt="" className="avatar avatar-lg" src={user.avatar_url} style={{ objectFit: 'cover' }} />
+        ) : (
+          <div className="avatar avatar-lg">{avatarInitial}</div>
+        )}
+
+        <div className="profile-info">
+          <h1 className="profile-name">{displayName}</h1>
+          <div className="profile-meta">
+            {metaItems.map((item, i) => (
+              <span key={item}>
+                {i > 0 && <span style={{ marginRight: 12 }}>·</span>}
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/profile/components/ProfilePage.tsx
+++ b/apps/web/src/features/profile/components/ProfilePage.tsx
@@ -121,28 +121,26 @@ export function ProfilePage() {
 
   if (isLoading) {
     return (
-      <section className="shell py-12">
-        <p className="text-muted">Loading your profile...</p>
-      </section>
+      <div className="profile-section">
+        <p style={{ color: 'var(--ink-4)', fontSize: '14px', margin: 0 }}>Loading your profile…</p>
+      </div>
     );
   }
 
   if (!profile) {
     return (
-      <section className="shell py-12">
-        <div className="card">
-          <h1>Profile unavailable</h1>
-          {errors.server ? <p className="text-muted">{errors.server}</p> : null}
-          <button className="btn btn-primary" onClick={() => void loadProfile()} type="button">
-            Try again
-          </button>
-        </div>
-      </section>
+      <div className="profile-section">
+        <h2>Account</h2>
+        {errors.server && <p style={{ color: 'var(--ink-4)', fontSize: '14px' }}>{errors.server}</p>}
+        <button className="btn btn-primary" onClick={() => void loadProfile()} type="button">
+          Try again
+        </button>
+      </div>
     );
   }
 
   return (
-    <section className="shell py-12">
+    <div className="profile-section">
       <ProfileForm
         errors={errors}
         fields={fields}
@@ -152,6 +150,6 @@ export function ProfilePage() {
         profile={profile}
         successMessage={successMessage}
       />
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/features/profile/components/ProfilePasswordSection.tsx
+++ b/apps/web/src/features/profile/components/ProfilePasswordSection.tsx
@@ -1,0 +1,23 @@
+export function ProfilePasswordSection() {
+  return (
+    <div className="profile-section">
+      <h2>Change password</h2>
+      <div className="field">
+        <label htmlFor="pw-current">Current password</label>
+        <input disabled id="pw-current" placeholder="Enter your current password" type="password" />
+      </div>
+      <div className="field-row">
+        <div className="field">
+          <label htmlFor="pw-new">New password</label>
+          <input disabled id="pw-new" placeholder="At least 8 characters" type="password" />
+        </div>
+        <div className="field">
+          <label htmlFor="pw-confirm">Confirm new password</label>
+          <input disabled id="pw-confirm" placeholder="Repeat new password" type="password" />
+        </div>
+      </div>
+      <button className="btn" disabled type="button">Update password</button>
+      <p className="hint" style={{ marginTop: 10, marginBottom: 0 }}>Password change coming soon.</p>
+    </div>
+  );
+}

--- a/apps/web/src/features/profile/components/ProfileRecentlyViewed.tsx
+++ b/apps/web/src/features/profile/components/ProfileRecentlyViewed.tsx
@@ -1,0 +1,11 @@
+export function ProfileRecentlyViewed() {
+  return (
+    <div className="profile-section">
+      <h2>Recently viewed</h2>
+      <p style={{ fontSize: '14px', color: 'var(--ink-4)', margin: '0 0 14px' }}>
+        No reading history yet.
+      </p>
+      <a className="btn btn-sm btn-ghost" href="/blog">Browse posts →</a>
+    </div>
+  );
+}

--- a/apps/web/src/features/profile/components/ProfileSidebar.tsx
+++ b/apps/web/src/features/profile/components/ProfileSidebar.tsx
@@ -1,0 +1,60 @@
+import { useCurrentSession } from '@/features/auth/session';
+
+export function ProfileSidebar() {
+  const { user } = useCurrentSession();
+
+  const memberSince = user
+    ? new Date().toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+    : '—';
+
+  return (
+    <aside className="profile-sidebar">
+      <div className="side-card">
+        <h4>Reading stats</h4>
+        <div>
+          <div className="stat-row">
+            <span className="label">Posts read</span>
+            <span className="value">—</span>
+          </div>
+          <div className="stat-row">
+            <span className="label">Comments written</span>
+            <span className="value">—</span>
+          </div>
+          <div className="stat-row">
+            <span className="label">Member since</span>
+            <span className="value">{memberSince}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="side-card">
+        <h4>Notifications</h4>
+        <div className="field" style={{ marginBottom: 12 }}>
+          <label htmlFor="notif-replies">Replies to my comments</label>
+          <select disabled id="notif-replies">
+            <option>Email me immediately</option>
+            <option>Weekly digest</option>
+            <option>None</option>
+          </select>
+        </div>
+        <div className="field" style={{ marginBottom: 14 }}>
+          <label htmlFor="notif-posts">New posts</label>
+          <select defaultValue="None" disabled id="notif-posts">
+            <option>Email on publish</option>
+            <option>Weekly digest</option>
+            <option>None</option>
+          </select>
+        </div>
+        <p className="hint" style={{ marginBottom: 0 }}>Notification settings coming soon.</p>
+      </div>
+
+      <div className="side-card">
+        <h4>Quick links</h4>
+        <div style={{ display: 'grid', gap: 6 }}>
+          <a className="btn btn-sm btn-ghost" href="/blog">Browse all posts →</a>
+          <a className="btn btn-sm btn-ghost" href="/contact">Contact support →</a>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -717,6 +717,30 @@
     border-color: var(--accent);
   }
 
+  .field select {
+    width: 100%;
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    background: var(--paper);
+    color: var(--ink);
+    padding: 11px 14px;
+    font-family: var(--font-sans);
+    font-size: 14px;
+    outline: none;
+    transition: border-color 150ms ease;
+    appearance: none;
+    cursor: pointer;
+  }
+
+  .field select:focus {
+    border-color: var(--accent);
+  }
+
+  .field select:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
   .field input.is-error {
     border-color: oklch(0.55 0.18 25);
   }
@@ -1138,5 +1162,206 @@
 
   .mode-toggle .txt {
     display: none;
+  }
+}
+
+/* ── Profile page ── */
+
+.profile-head {
+  padding: 48px 0 32px;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.profile-info { flex: 1; }
+
+.profile-name {
+  font-family: var(--font-sans);
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0 0 4px;
+}
+
+.profile-meta {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-4);
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.profile-layout {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 56px;
+  padding: 48px 0 96px;
+  align-items: start;
+}
+
+.profile-section {
+  margin-bottom: 40px;
+  padding-bottom: 36px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.profile-section:last-child {
+  border-bottom: 0;
+  margin-bottom: 0;
+}
+
+.profile-section h2 {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 18px;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.comment-list { display: grid; gap: 12px; }
+
+.comment-item {
+  padding: 14px 16px;
+  background: var(--paper-2);
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+}
+
+.comment-item .on {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  margin-bottom: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.comment-item .on a { color: var(--accent-ink); }
+.comment-item .on a:hover { color: var(--accent); }
+.comment-item p { font-size: 14px; color: var(--ink-2); margin: 0; line-height: 1.55; }
+
+.viewed-list { display: grid; gap: 10px; }
+
+.viewed-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule-2);
+}
+
+.viewed-item:last-child { border-bottom: 0; }
+.viewed-item a { font-size: 14px; font-weight: 500; color: var(--ink-2); line-height: 1.35; }
+.viewed-item a:hover { color: var(--accent-ink); }
+
+.viewed-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  text-align: right;
+  white-space: nowrap;
+  display: grid;
+  gap: 2px;
+}
+
+.read-progress-bar {
+  height: 4px;
+  background: var(--rule);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 6px;
+}
+
+.read-progress-bar > i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+}
+
+.danger-section {
+  border: 1px solid oklch(0.75 0.1 20);
+  border-radius: 8px;
+  padding: 20px;
+  background: color-mix(in oklab, oklch(0.96 0.03 20) 40%, var(--paper));
+}
+
+html[data-mode="dark"] .danger-section {
+  background: color-mix(in oklab, oklch(0.2 0.05 20) 30%, var(--paper-2));
+}
+
+.danger-section h2 {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 8px;
+  color: oklch(0.42 0.14 20);
+}
+
+.danger-section p {
+  font-size: 13px;
+  color: var(--ink-3);
+  margin: 0 0 14px;
+  line-height: 1.55;
+}
+
+.profile-sidebar { display: grid; gap: 20px; align-content: start; }
+
+.side-card {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  padding: 18px;
+}
+
+.side-card h4 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--rule);
+  font-size: 13px;
+}
+
+.stat-row:last-child { border-bottom: 0; }
+.stat-row .label { color: var(--ink-3); }
+.stat-row .value { font-family: var(--font-mono); font-size: 12px; font-weight: 600; color: var(--ink-2); }
+
+@media (max-width: 900px) {
+  .profile-layout {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+}
+
+@media (max-width: 540px) {
+  .field-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/architecture/profile-page.md
+++ b/docs/architecture/profile-page.md
@@ -11,15 +11,23 @@ This document defines the structure, data flow, and implementation plan for the 
 ## Implementation Progress
 
 ```text
-1. Profile page layout and CSS        done
-2. Profile head (avatar, name, handle, member since) done — reads from session
-3. Account form (display name, email)  done — wired to PATCH /api/v1/profile
-4. Password section                    stub — UI only, not wired
-5. Comment history                     stub — no data yet
-6. Recently viewed                     stub — no data yet
-7. Danger zone (delete account)        stub — UI only, disabled
-8. Sidebar (stats, notifications)      stub — reads member-since from session
+1. Frontend profile UI              done — layout, all components, CSS ported from design
+2. Backend profile endpoints        done — GET/PATCH/DELETE /api/v1/profile wired and auth-gated
+3. Frontend account form wiring     done — reads PrivateProfile, writes via PATCH, refreshes session
+4. Password change                  pending — UI stub only; needs Supabase updateUser wiring
+5. Comment history                  pending — needs GET /api/v1/profile/comments backend endpoint
+6. Recently viewed                  pending — needs GET /api/v1/profile/reading-history endpoint
+7. Notifications                    pending — UI stub only; no backend endpoint yet
+8. Delete account                   pending — UI stub only; DELETE /api/v1/profile not wired
+9. Security review                  pending — ownership checks, rate limiting on profile mutations
+10. Cleanup                         pending — remove stubs, wire real data, remove disabled states
 ```
+
+Frontend profile UI covers all eight components (`ProfileHead`, `ProfilePage`, `ProfilePasswordSection`, `ProfileCommentHistory`, `ProfileRecentlyViewed`, `ProfileDangerZone`, `ProfileSidebar`, `ProfileForm`), the full CSS port from `design/profile.html`, and session data displayed without extra fetches (`display_name`, `handle`, `avatar_url`, `created_at`).
+
+Backend profile endpoints cover `ProfileController` behind `auth:api` middleware, `ProfileResource` and `ProfileService`, the `GET /api/v1/profile` load, `PATCH /api/v1/profile` update, and the `DELETE /api/v1/profile` route stub. The session endpoint (`GET /api/v1/session`) returns `created_at` via `SessionResource` so `ProfileHead` has member-since without a separate fetch.
+
+Pending phases require backend endpoints for comment history and reading history before the corresponding frontend components can be wired. Password change goes through Supabase `updateUser` — no new Laravel endpoint needed, only frontend wiring. Notifications and delete account need both backend endpoints and frontend wiring.
 
 ## Route and Auth
 
@@ -37,15 +45,15 @@ The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group lay
 
 ```text
 /profile
-├── ProfileHead              — avatar, display name, handle
+├── ProfileHead              — avatar, display name, handle, member since
 │
 └── .shell.profile-layout    — two-column grid (1fr 300px, collapses at 900px)
     ├── Left column
-    │   ├── ProfilePage          — account form (display name, avatar, name fields)
+    │   ├── ProfilePage          — account form (display name, first/last name, avatar URL, email)
     │   ├── ProfilePasswordSection — change password (stub)
     │   ├── ProfileCommentHistory  — user's past comments (stub)
     │   ├── ProfileRecentlyViewed  — reading history (stub)
-    │   └── ProfileDangerZone      — delete account (disabled)
+    │   └── ProfileDangerZone      — delete account (stub)
     │
     └── Right column
         └── ProfileSidebar     — reading stats, notifications, quick links
@@ -87,20 +95,20 @@ The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group lay
 
 - Source: `src/features/profile/components/ProfileRecentlyViewed.tsx`
 - Status: **stub** — shows empty state.
-- Future: `GET /api/v1/profile/reading-history` or local storage tracking.
+- Future: `GET /api/v1/profile/reading-history` with read progress percentage per post.
 
 ### ProfileDangerZone
 
 - Source: `src/features/profile/components/ProfileDangerZone.tsx`
 - Status: **stub** — delete button disabled.
-- Future: `DELETE /api/v1/profile` with a confirmation modal.
+- Future: `DELETE /api/v1/profile` with a confirmation modal before calling the endpoint.
 
 ### ProfileSidebar
 
 - Source: `src/features/profile/components/ProfileSidebar.tsx`
-- Status: reading stats and notifications are placeholder values.
+- Status: reading stats show `—` placeholders; notifications dropdowns are disabled.
 - Quick links (Browse posts, Contact support) are live.
-- Future: stats wired to comment count and reading history API.
+- Future: stats wired to comment count and reading history endpoints; notifications saved via backend.
 
 ## API Touchpoints
 
@@ -108,11 +116,12 @@ The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group lay
 Authenticated user (/profile)
 ├── GET  /api/v1/profile        — load private profile fields
 ├── PATCH /api/v1/profile       — update display_name, first_name, last_name, avatar_url
-└── DELETE /api/v1/profile      — delete account (not yet wired)
+└── DELETE /api/v1/profile      — delete account (route exists, not wired on frontend)
 
 Future
 ├── GET /api/v1/profile/comments         — comment history list
-└── GET /api/v1/profile/reading-history  — recently viewed posts
+├── GET /api/v1/profile/reading-history  — recently viewed posts with progress
+└── PATCH /api/v1/profile/notifications  — save notification preferences
 ```
 
 ## Data Flow
@@ -151,18 +160,21 @@ All profile page styles live in `src/styles/theme.css` under the `/* ── Prof
 .field select        — styled dropdown (width, border, padding, appearance reset)
 ```
 
-## Acceptance Checks
+## Current Acceptance Checks
 
 - Signed-out users visiting `/profile` are redirected to `/signin`.
 - Signed-in users see their avatar initial (or image if set), display name, handle, and member-since date in the header.
-- The account form pre-fills with current profile data from the API.
-- Saving the account form updates the API and refreshes the session so the header name updates.
-- Password section, comment history, recently viewed, and delete account are visible but clearly marked as coming soon or disabled.
+- The account form pre-fills with current profile data from `GET /api/v1/profile`.
+- Saving the account form updates the API and refreshes the session so the header name updates immediately.
+- Password section, comment history, recently viewed, notifications, and delete account are visible but clearly rendered as stubs (disabled inputs, empty states, disabled buttons).
 - The layout collapses to a single column on screens narrower than 900px.
+- Field rows (first name / last name) collapse to a single column on screens narrower than 540px.
 
 ## Future Acceptance Checks
 
-- Password change works via Supabase `updateUser` and signs the user out after success.
-- Comment history shows the last N comments with links to the originating post.
-- Recently viewed shows posts with a reading progress bar.
-- Delete account shows a confirmation modal before calling `DELETE /api/v1/profile`.
+- Password change wires Supabase `updateUser({ password })`, signs the user out after success, and redirects to `/signin`.
+- Comment history shows the last N comments with a link to the originating post and a timestamp.
+- Recently viewed shows posts with a read progress bar and the last-viewed date.
+- Notifications dropdowns save preferences via a backend endpoint and confirm on save.
+- Delete account shows a confirmation modal before calling `DELETE /api/v1/profile`; public comments are anonymised on deletion.
+- Profile mutations (`PATCH`, `DELETE`) reject requests where the authenticated user does not own the target record.

--- a/docs/architecture/profile-page.md
+++ b/docs/architecture/profile-page.md
@@ -1,0 +1,168 @@
+# Profile Page
+
+## Purpose
+
+This document defines the structure, data flow, and implementation plan for the private user profile page at `/profile`.
+
+- `/profile` is auth-protected and only accessible to signed-in users.
+- `/profile/:handle` is the public-facing profile (separate page, not covered here).
+- The profile page is the primary surface where users manage their account, password, notification preferences, and view their reading/comment activity.
+
+## Implementation Progress
+
+```text
+1. Profile page layout and CSS        done
+2. Profile head (avatar, name, handle, member since) done — reads from session
+3. Account form (display name, email)  done — wired to PATCH /api/v1/profile
+4. Password section                    stub — UI only, not wired
+5. Comment history                     stub — no data yet
+6. Recently viewed                     stub — no data yet
+7. Danger zone (delete account)        stub — UI only, disabled
+8. Sidebar (stats, notifications)      stub — reads member-since from session
+```
+
+## Route and Auth
+
+The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group layout (`pages/(user)/+Layout.tsx`) wraps every page in this group with:
+
+```tsx
+<AppShell>
+  <RequireAuth>{children}</RequireAuth>
+</AppShell>
+```
+
+`RequireAuth` redirects unauthenticated visitors to `/signin`. The page itself does not need to repeat the auth guard.
+
+## Page Structure
+
+```text
+/profile
+├── ProfileHead              — avatar, display name, handle
+│
+└── .shell.profile-layout    — two-column grid (1fr 300px, collapses at 900px)
+    ├── Left column
+    │   ├── ProfilePage          — account form (display name, avatar, name fields)
+    │   ├── ProfilePasswordSection — change password (stub)
+    │   ├── ProfileCommentHistory  — user's past comments (stub)
+    │   ├── ProfileRecentlyViewed  — reading history (stub)
+    │   └── ProfileDangerZone      — delete account (disabled)
+    │
+    └── Right column
+        └── ProfileSidebar     — reading stats, notifications, quick links
+```
+
+## Component Breakdown
+
+### ProfileHead
+
+- Source: `src/features/profile/components/ProfileHead.tsx`
+- Data: `useCurrentSession().user` — `display_name`, `handle`, `avatar_url`, `created_at`
+- Renders the page header with avatar (image or initial fallback), display name, handle, and member-since date.
+- `created_at` is included in the session response (`SessionResource.php`) so no extra fetch is needed.
+- `SessionUser` type (`authTypes.ts`) includes `created_at: string | null`.
+
+### ProfilePage (account form)
+
+- Source: `src/features/profile/components/ProfilePage.tsx`
+- API: `GET /api/v1/profile` → `fetchPrivateProfile`, `PATCH /api/v1/profile` → `updatePrivateProfile`
+- Fields: `display_name`, `first_name`, `last_name`, `avatar_url`
+- Read-only display: `email` (shown in form with hint text)
+- Calls `refreshSession()` after a successful update so the header reflects name changes.
+- Delegates rendering to `ProfileForm` which uses `.profile-section`, `.field`, `.field-row`, `.field-error`, `.form-alert`, `.hint` CSS classes.
+
+### ProfilePasswordSection
+
+- Source: `src/features/profile/components/ProfilePasswordSection.tsx`
+- Status: **stub** — UI rendered, inputs disabled.
+- Future: Supabase `updateUser({ password })` after verifying current password.
+- Password changes do not go through Laravel — Supabase owns credentials.
+
+### ProfileCommentHistory
+
+- Source: `src/features/profile/components/ProfileCommentHistory.tsx`
+- Status: **stub** — shows empty state.
+- Future: `GET /api/v1/profile/comments` (not yet implemented in backend).
+
+### ProfileRecentlyViewed
+
+- Source: `src/features/profile/components/ProfileRecentlyViewed.tsx`
+- Status: **stub** — shows empty state.
+- Future: `GET /api/v1/profile/reading-history` or local storage tracking.
+
+### ProfileDangerZone
+
+- Source: `src/features/profile/components/ProfileDangerZone.tsx`
+- Status: **stub** — delete button disabled.
+- Future: `DELETE /api/v1/profile` with a confirmation modal.
+
+### ProfileSidebar
+
+- Source: `src/features/profile/components/ProfileSidebar.tsx`
+- Status: reading stats and notifications are placeholder values.
+- Quick links (Browse posts, Contact support) are live.
+- Future: stats wired to comment count and reading history API.
+
+## API Touchpoints
+
+```text
+Authenticated user (/profile)
+├── GET  /api/v1/profile        — load private profile fields
+├── PATCH /api/v1/profile       — update display_name, first_name, last_name, avatar_url
+└── DELETE /api/v1/profile      — delete account (not yet wired)
+
+Future
+├── GET /api/v1/profile/comments         — comment history list
+└── GET /api/v1/profile/reading-history  — recently viewed posts
+```
+
+## Data Flow
+
+```text
+User lands on /profile
+└── (user)/+Layout.tsx checks session via RequireAuth
+    └── If unauthenticated: redirect to /signin
+    └── If authenticated: render page
+        └── ProfileHead reads useCurrentSession().user (no extra fetch)
+        └── ProfilePage fetches GET /api/v1/profile (separate from session)
+            └── On submit: PATCH /api/v1/profile -> refreshSession()
+```
+
+## CSS Classes
+
+All profile page styles live in `src/styles/theme.css` under the `/* ── Profile page ── */` section.
+
+```text
+.profile-head        — flex header with avatar and info
+.profile-info        — name + meta container
+.profile-name        — h1 display name
+.profile-meta        — handle, member since (mono, small)
+.profile-layout      — two-column grid layout
+.profile-section     — left-column section with bottom border
+.field-row           — two-column field grid (collapses at 540px)
+.comment-list        — comment items grid
+.comment-item        — individual comment card
+.viewed-list         — recently viewed items
+.viewed-item         — single viewed post row with progress bar
+.read-progress-bar   — horizontal reading progress indicator
+.danger-section      — red-tinted delete account card
+.profile-sidebar     — right sidebar grid
+.side-card           — sidebar card with bordered header
+.stat-row            — flex row with label and mono value
+.field select        — styled dropdown (width, border, padding, appearance reset)
+```
+
+## Acceptance Checks
+
+- Signed-out users visiting `/profile` are redirected to `/signin`.
+- Signed-in users see their avatar initial (or image if set), display name, handle, and member-since date in the header.
+- The account form pre-fills with current profile data from the API.
+- Saving the account form updates the API and refreshes the session so the header name updates.
+- Password section, comment history, recently viewed, and delete account are visible but clearly marked as coming soon or disabled.
+- The layout collapses to a single column on screens narrower than 900px.
+
+## Future Acceptance Checks
+
+- Password change works via Supabase `updateUser` and signs the user out after success.
+- Comment history shows the last N comments with links to the originating post.
+- Recently viewed shows posts with a reading progress bar.
+- Delete account shows a confirmation modal before calling `DELETE /api/v1/profile`.


### PR DESCRIPTION
## Summary

- Build out private `/profile` page from `design/profile.html`
- All sections rendered with real data where available, stubs where backend endpoints are pending
- Added `created_at` to session so member since displays without an extra fetch

## Changes

**New components**
- `ProfileHead` — avatar, display name, handle, member since (from session, no extra fetch)
- `ProfilePasswordSection` — change password stub
- `ProfileCommentHistory` — comment history stub with empty state
- `ProfileRecentlyViewed` — reading history stub with empty state
- `ProfileDangerZone` — delete account stub

**Updated components**
- `ProfileForm` — rewritten to use design system CSS classes (`.field`, `.field-row`, `.form-alert`, `.hint`); fields: display name, first/last name, avatar URL, read-only email
- `ProfilePage` — loading/error states updated to match design layout

**Backend**
- `SessionResource.php` — added `created_at` to session response
- `authTypes.ts` — added `created_at: string | null` to `SessionUser` type