### PR TITLE
Ssr component refactor

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.1",
         "@tailwindcss/vite": "^4.2.4",
         "lucide-react": "^1.14.0",
@@ -1096,9 +1097,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.105.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.1.tgz",
-      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
+      "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1108,9 +1109,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.105.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.1.tgz",
-      "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
+      "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1126,9 +1127,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.105.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.1.tgz",
-      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
+      "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1138,9 +1139,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.105.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.1.tgz",
-      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
+      "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "^0.4.1",
@@ -1152,10 +1153,22 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.3.tgz",
+      "integrity": "sha512-ux2CJgX89h0Fz2lY7ZNafNG2SkXpyRc5dz77K9eKeBLPdtywQixKwIuetDeIViAJBp/buOUVmgj8PVesOklNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.105.3"
+      }
+    },
     "node_modules/@supabase/storage-js": {
-      "version": "2.105.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.1.tgz",
-      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
+      "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -1166,16 +1179,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.105.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.1.tgz",
-      "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.3.tgz",
+      "integrity": "sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.105.1",
-        "@supabase/functions-js": "2.105.1",
-        "@supabase/postgrest-js": "2.105.1",
-        "@supabase/realtime-js": "2.105.1",
-        "@supabase/storage-js": "2.105.1"
+        "@supabase/auth-js": "2.105.3",
+        "@supabase/functions-js": "2.105.3",
+        "@supabase/postgrest-js": "2.105.3",
+        "@supabase/realtime-js": "2.105.3",
+        "@supabase/storage-js": "2.105.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2005,6 +2018,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.1",
     "@tailwindcss/vite": "^4.2.4",
     "lucide-react": "^1.14.0",

--- a/apps/web/pages/(auth)/+Layout.tsx
+++ b/apps/web/pages/(auth)/+Layout.tsx
@@ -1,16 +1,7 @@
 import type { ReactNode } from "react";
-import { usePageContext } from "vike-react/usePageContext";
 
-import { RequireGuest } from "@/features/auth/guards";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
-  const { urlPathname } = usePageContext();
-
-  // Reset-password creates a Supabase session mid-flow (recovery token exchange).
-  // RequireGuest would redirect the user away the moment that session is set,
-  // so this route must bypass the guest guard.
-  if (urlPathname === "/reset-password") return <ErrorBoundary>{children}</ErrorBoundary>;
-
-  return <RequireGuest><ErrorBoundary>{children}</ErrorBoundary></RequireGuest>;
+  return <ErrorBoundary>{children}</ErrorBoundary>;
 }

--- a/apps/web/pages/(auth)/+config.ts
+++ b/apps/web/pages/(auth)/+config.ts
@@ -1,0 +1,5 @@
+import type { Config } from 'vike/types';
+
+export default {
+  prerender: false,
+} satisfies Config;

--- a/apps/web/pages/(auth)/+guard.ts
+++ b/apps/web/pages/(auth)/+guard.ts
@@ -4,9 +4,10 @@ import type { PageContextServer } from 'vike/types';
 import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
 
 export async function guard(pageContext: PageContextServer) {
-  if (typeof window !== 'undefined') return;
-
-  if (pageContext.urlPathname === '/reset-password') return;
+  // /reset-password: Supabase recovery token fires SIGNED_IN, must not be blocked by guest gate
+  // /auth/callback: handles the OAuth/email code exchange — must run regardless of session state
+  const bypassed = ['/reset-password', '/auth/callback'];
+  if (bypassed.includes(pageContext.urlPathname)) return;
 
   const supabase = createSupabaseServerClient(
     pageContext.headers as Record<string, string> | null,

--- a/apps/web/pages/(auth)/+guard.ts
+++ b/apps/web/pages/(auth)/+guard.ts
@@ -1,0 +1,22 @@
+import { redirect } from 'vike/abort';
+import type { PageContextServer } from 'vike/types';
+
+import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
+
+export async function guard(pageContext: PageContextServer) {
+  if (typeof window !== 'undefined') return;
+
+  if (pageContext.urlPathname === '/reset-password') return;
+
+  const supabase = createSupabaseServerClient(
+    pageContext.headers as Record<string, string> | null,
+  );
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session) {
+    throw redirect('/');
+  }
+}

--- a/apps/web/pages/(auth)/auth/callback/+Page.tsx
+++ b/apps/web/pages/(auth)/auth/callback/+Page.tsx
@@ -53,6 +53,11 @@ export default function Page() {
           return;
         }
       } else if (hashAccessToken && hashRefreshToken) {
+        // Hash-fragment path: handles Supabase email magic links and email confirmations.
+        // OAuth flows always use the ?code= PKCE path above; hash tokens are only issued for email flows.
+        // Tokens are Supabase-signed JWTs — they cannot be forged by an attacker.
+        // Residual session-fixation risk (attacker-crafted URL with own tokens) is accepted as a
+        // known limitation; fully eliminating it requires configuring Supabase email to use PKCE.
         const { error } = await supabase.auth.setSession({
           access_token: hashAccessToken,
           refresh_token: hashRefreshToken,

--- a/apps/web/pages/(user)/+Layout.tsx
+++ b/apps/web/pages/(user)/+Layout.tsx
@@ -1,12 +1,11 @@
 import type { ReactNode } from "react";
 
-import { RequireAuth } from "@/features/auth/guards";
 import { AppShell } from "@/layouts/AppShell";
 
 export default function UserLayout({ children }: { children: ReactNode }) {
   return (
     <AppShell>
-      <RequireAuth>{children}</RequireAuth>
+      {children}
     </AppShell>
   );
 }

--- a/apps/web/pages/(user)/+config.ts
+++ b/apps/web/pages/(user)/+config.ts
@@ -1,0 +1,5 @@
+import type { Config } from 'vike/types';
+
+export default {
+  prerender: false,
+} satisfies Config;

--- a/apps/web/pages/(user)/+guard.ts
+++ b/apps/web/pages/(user)/+guard.ts
@@ -1,0 +1,20 @@
+import { redirect } from 'vike/abort';
+import type { PageContextServer } from 'vike/types';
+
+import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
+
+export async function guard(pageContext: PageContextServer) {
+  if (typeof window !== 'undefined') return;
+
+  const supabase = createSupabaseServerClient(
+    pageContext.headers as Record<string, string> | null,
+  );
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    throw redirect('/signin');
+  }
+}

--- a/apps/web/pages/(user)/+guard.ts
+++ b/apps/web/pages/(user)/+guard.ts
@@ -4,8 +4,6 @@ import type { PageContextServer } from 'vike/types';
 import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
 
 export async function guard(pageContext: PageContextServer) {
-  if (typeof window !== 'undefined') return;
-
   const supabase = createSupabaseServerClient(
     pageContext.headers as Record<string, string> | null,
   );

--- a/apps/web/pages/(user)/profile/+Page.tsx
+++ b/apps/web/pages/(user)/profile/+Page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
 
   return (
     <>
-      <ProfileHead />
+      <ProfileHead profile={profile} />
       <ErrorBoundary>
         <div className="shell profile-layout">
           <div>

--- a/apps/web/pages/(user)/profile/+Page.tsx
+++ b/apps/web/pages/(user)/profile/+Page.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+import { useData } from "vike-react/useData";
 
 import type { PrivateProfile } from "@/features/profile/profileTypes";
+import type { ProfilePageData } from "@/features/profile/profileTypes";
 
 import { ProfileHead } from "@/features/profile/components/ProfileHead";
 import { ProfilePage } from "@/features/profile/components/ProfilePage";
@@ -12,7 +14,8 @@ import { ProfileSidebar } from "@/features/profile/components/ProfileSidebar";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 export default function Page() {
-  const [profile, setProfile] = useState<PrivateProfile | null>(null);
+  const data = useData<ProfilePageData>();
+  const [profile, setProfile] = useState<PrivateProfile>(data.profile);
 
   return (
     <>
@@ -20,10 +23,10 @@ export default function Page() {
       <ErrorBoundary>
         <div className="shell profile-layout">
           <div>
-            <ProfilePage onProfileChange={setProfile} />
+            <ProfilePage initialProfile={profile} onProfileChange={setProfile} />
             <ProfilePasswordSection />
-            <ProfileCommentHistory />
-            <ProfileRecentlyViewed />
+            <ProfileCommentHistory initialComments={data.comments} />
+            <ProfileRecentlyViewed initialHistory={data.readingHistory} />
             <ProfileDangerZone />
           </div>
           <ProfileSidebar profile={profile} onProfileChange={setProfile} />

--- a/apps/web/pages/(user)/profile/+data.ts
+++ b/apps/web/pages/(user)/profile/+data.ts
@@ -1,7 +1,6 @@
 import { redirect } from 'vike/abort';
 import type { PageContextServer } from 'vike/types';
 
-import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
 import {
   fetchPrivateProfile,
   fetchProfileComments,
@@ -10,25 +9,26 @@ import {
 import type { ProfilePageData } from '@/features/profile/profileTypes';
 
 export async function data(pageContext: PageContextServer): Promise<ProfilePageData> {
-  const supabase = createSupabaseServerClient(
-    pageContext.headers as Record<string, string> | null,
-  );
+  // onBeforeRender runs before data() and sets userAccessToken from the session cookie.
+  // The guard already redirected guests, so a missing token here is an edge case.
+  const accessToken = pageContext.userAccessToken;
 
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session?.access_token) {
+  if (!accessToken) {
     throw redirect('/signin');
   }
 
-  const accessToken = session.access_token;
+  // Profile is required — let it throw and surface a 500 if the backend is unreachable.
+  const profile = await fetchPrivateProfile(accessToken);
 
-  const [profile, comments, readingHistory] = await Promise.all([
-    fetchPrivateProfile(accessToken),
+  // Comments and history are display-only — degrade gracefully to empty on failure.
+  const [commentsResult, historyResult] = await Promise.allSettled([
     fetchProfileComments(accessToken),
     fetchReadingHistory(accessToken),
   ]);
 
-  return { profile, comments, readingHistory };
+  return {
+    profile,
+    comments: commentsResult.status === 'fulfilled' ? commentsResult.value : [],
+    readingHistory: historyResult.status === 'fulfilled' ? historyResult.value : [],
+  };
 }

--- a/apps/web/pages/(user)/profile/+data.ts
+++ b/apps/web/pages/(user)/profile/+data.ts
@@ -6,16 +6,25 @@ import {
   fetchProfileComments,
   fetchReadingHistory,
 } from '@/features/profile/api/profileApi';
+import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
 import type { ProfilePageData } from '@/features/profile/profileTypes';
 
 export async function data(pageContext: PageContextServer): Promise<ProfilePageData> {
-  // onBeforeRender runs before data() and sets userAccessToken from the session cookie.
-  // The guard already redirected guests, so a missing token here is an edge case.
-  const accessToken = pageContext.userAccessToken;
+  // data() runs before onBeforeRender() in Vike, so pageContext.userAccessToken is not
+  // yet available here. Read the session directly from the cookie instead.
+  const supabase = createSupabaseServerClient(
+    pageContext.headers as Record<string, string> | null,
+  );
 
-  if (!accessToken) {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.access_token) {
     throw redirect('/signin');
   }
+
+  const accessToken = session.access_token;
 
   // Profile is required — let it throw and surface a 500 if the backend is unreachable.
   const profile = await fetchPrivateProfile(accessToken);

--- a/apps/web/pages/(user)/profile/+data.ts
+++ b/apps/web/pages/(user)/profile/+data.ts
@@ -1,0 +1,34 @@
+import { redirect } from 'vike/abort';
+import type { PageContextServer } from 'vike/types';
+
+import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
+import {
+  fetchPrivateProfile,
+  fetchProfileComments,
+  fetchReadingHistory,
+} from '@/features/profile/api/profileApi';
+import type { ProfilePageData } from '@/features/profile/profileTypes';
+
+export async function data(pageContext: PageContextServer): Promise<ProfilePageData> {
+  const supabase = createSupabaseServerClient(
+    pageContext.headers as Record<string, string> | null,
+  );
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.access_token) {
+    throw redirect('/signin');
+  }
+
+  const accessToken = session.access_token;
+
+  const [profile, comments, readingHistory] = await Promise.all([
+    fetchPrivateProfile(accessToken),
+    fetchProfileComments(accessToken),
+    fetchReadingHistory(accessToken),
+  ]);
+
+  return { profile, comments, readingHistory };
+}

--- a/apps/web/pages/+config.ts
+++ b/apps/web/pages/+config.ts
@@ -3,5 +3,6 @@ import vikeReact from 'vike-react/config'
 
 export default {
   extends: vikeReact,
-  prerender: true
+  prerender: true,
+  passToClient: ['initialUser'],
 } satisfies Config

--- a/apps/web/pages/+onBeforeRender.ts
+++ b/apps/web/pages/+onBeforeRender.ts
@@ -1,0 +1,34 @@
+import type { PageContextServer } from 'vike/types';
+
+import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
+import { fetchCurrentUser } from '@/features/auth/api/currentUserApi';
+
+export async function onBeforeRender(pageContext: PageContextServer) {
+  const supabase = createSupabaseServerClient(
+    pageContext.headers as Record<string, string> | null,
+  );
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.access_token) {
+    return { pageContext: { initialUser: null } };
+  }
+
+  try {
+    const currentSession = await fetchCurrentUser(session.access_token);
+
+    return {
+      pageContext: {
+        initialUser: {
+          displayName: currentSession.user.display_name,
+          handle: currentSession.user.handle,
+          isAdmin: currentSession.permissions.admin,
+        },
+      },
+    };
+  } catch {
+    return { pageContext: { initialUser: null } };
+  }
+}

--- a/apps/web/pages/+onBeforeRender.ts
+++ b/apps/web/pages/+onBeforeRender.ts
@@ -14,7 +14,7 @@ function isAuthRoute(pathname: string): boolean {
 
 export async function onBeforeRender(pageContext: PageContextServer) {
   if (isAuthRoute(pageContext.urlPathname)) {
-    return { pageContext: { initialUser: null, userAccessToken: null } };
+    return { pageContext: { initialUser: null } };
   }
 
   const supabase = createSupabaseServerClient(
@@ -26,7 +26,7 @@ export async function onBeforeRender(pageContext: PageContextServer) {
   } = await supabase.auth.getSession();
 
   if (!session?.access_token) {
-    return { pageContext: { initialUser: null, userAccessToken: null } };
+    return { pageContext: { initialUser: null } };
   }
 
   const accessToken = session.access_token;
@@ -41,10 +41,9 @@ export async function onBeforeRender(pageContext: PageContextServer) {
           handle: currentSession.user.handle,
           isAdmin: currentSession.permissions.admin,
         },
-        userAccessToken: accessToken,
       },
     };
   } catch {
-    return { pageContext: { initialUser: null, userAccessToken: null } };
+    return { pageContext: { initialUser: null } };
   }
 }

--- a/apps/web/pages/+onBeforeRender.ts
+++ b/apps/web/pages/+onBeforeRender.ts
@@ -3,7 +3,20 @@ import type { PageContextServer } from 'vike/types';
 import { createSupabaseServerClient } from '@/lib/auth/supabaseServerClient';
 import { fetchCurrentUser } from '@/features/auth/api/currentUserApi';
 
+// Auth-shell pages have no site Header — skip the session call on these routes.
+const AUTH_ROUTES = ['/signin', '/signup', '/forgot-password', '/reset-password', '/auth/'];
+
+function isAuthRoute(pathname: string): boolean {
+  return AUTH_ROUTES.some(
+    (r) => pathname === r || pathname.startsWith(r),
+  );
+}
+
 export async function onBeforeRender(pageContext: PageContextServer) {
+  if (isAuthRoute(pageContext.urlPathname)) {
+    return { pageContext: { initialUser: null, userAccessToken: null } };
+  }
+
   const supabase = createSupabaseServerClient(
     pageContext.headers as Record<string, string> | null,
   );
@@ -13,11 +26,13 @@ export async function onBeforeRender(pageContext: PageContextServer) {
   } = await supabase.auth.getSession();
 
   if (!session?.access_token) {
-    return { pageContext: { initialUser: null } };
+    return { pageContext: { initialUser: null, userAccessToken: null } };
   }
 
+  const accessToken = session.access_token;
+
   try {
-    const currentSession = await fetchCurrentUser(session.access_token);
+    const currentSession = await fetchCurrentUser(accessToken);
 
     return {
       pageContext: {
@@ -26,9 +41,10 @@ export async function onBeforeRender(pageContext: PageContextServer) {
           handle: currentSession.user.handle,
           isAdmin: currentSession.permissions.admin,
         },
+        userAccessToken: accessToken,
       },
     };
   } catch {
-    return { pageContext: { initialUser: null } };
+    return { pageContext: { initialUser: null, userAccessToken: null } };
   }
 }

--- a/apps/web/src/components/layout/Header/Header.tsx
+++ b/apps/web/src/components/layout/Header/Header.tsx
@@ -23,18 +23,25 @@ export function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const pageContext = usePageContext();
   const pathname = pageContext.urlPathname;
+  const initialUser = pageContext.initialUser ?? null;
 
-  const { isLoading, isAuthenticated, isAdmin, user, signOut } =
+  const { isLoading: sessionLoading, isAuthenticated, isAdmin, user, signOut } =
     useCurrentSession();
+
+  const isLoading = sessionLoading && !initialUser;
 
   const guestCta =
     pathname === headerAuthButtons.signIn.href
       ? headerAuthButtons.signUp
       : headerAuthButtons.signIn;
-  const accountName = user?.display_name ?? "Account";
-  const accountHandle = user?.handle ?? "Signed in";
+  const accountName = user?.display_name ?? initialUser?.displayName ?? "Account";
+  const accountHandle = user?.handle ?? initialUser?.handle ?? "Signed in";
   const avatarInitial =
-    user?.display_name?.charAt(0) ?? user?.handle?.replace(/^@/, "").charAt(0) ?? "U";
+    user?.display_name?.charAt(0) ??
+    user?.handle?.replace(/^@/, "").charAt(0) ??
+    initialUser?.displayName?.charAt(0) ??
+    initialUser?.handle?.replace(/^@/, "").charAt(0) ??
+    "U";
 
   async function handleSignOut() {
     setIsAccountMenuOpen(false);
@@ -46,11 +53,14 @@ export function Header() {
     }
   }
 
+  const effectiveIsAuthenticated = isAuthenticated || (!!initialUser && sessionLoading);
+  const effectiveIsAdmin = isAdmin || (!!initialUser?.isAdmin && sessionLoading);
+
   const actions: HeaderActionItem[] = isLoading
     ? []
-    : isAuthenticated
+    : effectiveIsAuthenticated
       ? [
-          ...(isAdmin
+          ...(effectiveIsAdmin
             ? [
                 {
                   type: "link",
@@ -120,7 +130,7 @@ export function Header() {
               aria-hidden="true"
               className="hidden h-10 w-24 md:inline-flex"
             />
-          ) : isAuthenticated ? (
+          ) : effectiveIsAuthenticated ? (
             <div className="relative hidden md:block">
               <button
                 aria-expanded={isAccountMenuOpen}
@@ -193,7 +203,7 @@ export function Header() {
             )
           )}
 
-          {!isLoading && isAuthenticated ? (
+          {!isLoading && effectiveIsAuthenticated ? (
             <button
               aria-expanded={isMobileAccountMenuOpen}
               aria-haspopup="menu"
@@ -267,7 +277,7 @@ export function Header() {
 
       {isMobileMenuOpen ? (
         <HeaderMobileMenuPanel
-          actions={isAuthenticated ? [] : actions}
+          actions={effectiveIsAuthenticated ? [] : actions}
           items={headerNavItems}
           onClose={() => setIsMobileMenuOpen(false)}
         />

--- a/apps/web/src/features/auth/guards/AuthGuard.tsx
+++ b/apps/web/src/features/auth/guards/AuthGuard.tsx
@@ -3,6 +3,8 @@ import { useEffect } from "react";
 
 import { useCurrentSession } from "@/features/auth/session";
 
+// @deprecated — replaced by +guard.ts server-side hooks. Kept as fallback for admin routes and client navigation.
+
 type AuthGuardProps = {
   children: ReactNode;
   requireAdmin?: boolean;

--- a/apps/web/src/features/auth/guards/AuthGuard.tsx
+++ b/apps/web/src/features/auth/guards/AuthGuard.tsx
@@ -18,7 +18,7 @@ export function AuthGuard({
   guestRedirectTo = "/signin",
   forbiddenRedirectTo = "/profile",
 }: AuthGuardProps) {
-  const { status, error, isLoading, isAuthenticated, isAdmin, refreshSession } =
+  const { status, isLoading, isAuthenticated, isAdmin, refreshSession } =
     useCurrentSession();
 
   const isForbidden = isAuthenticated && requireAdmin && !isAdmin;
@@ -55,7 +55,7 @@ export function AuthGuard({
     return (
       <div className="shell py-12">
         <h1>Session unavailable</h1>
-        <p className="text-ink-4">{error}</p>
+        <p className="text-ink-4">Unable to load your session. Please try again.</p>
         <button
           className="btn btn-primary"
           onClick={() => void refreshSession()}

--- a/apps/web/src/features/auth/guards/RequireAuth.tsx
+++ b/apps/web/src/features/auth/guards/RequireAuth.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 
 import { AuthGuard } from "@/features/auth/guards/AuthGuard";
 
+// @deprecated — replaced by +guard.ts server-side hooks. Kept as fallback for admin routes and client navigation.
+
 export function RequireAuth({ children }: { children: ReactNode }) {
   return <AuthGuard>{children}</AuthGuard>;
 }

--- a/apps/web/src/features/auth/guards/RequireGuest.tsx
+++ b/apps/web/src/features/auth/guards/RequireGuest.tsx
@@ -3,6 +3,8 @@ import { useEffect } from "react";
 
 import { useCurrentSession } from "@/features/auth/session";
 
+// @deprecated — replaced by +guard.ts server-side hooks. Kept as fallback for admin routes and client navigation.
+
 export function RequireGuest({ children }: { children: ReactNode }) {
   const { isAdmin, isAuthenticated, isLoading } = useCurrentSession();
 

--- a/apps/web/src/features/profile/components/ProfileCommentHistory.tsx
+++ b/apps/web/src/features/profile/components/ProfileCommentHistory.tsx
@@ -4,10 +4,11 @@ import { useProfileFetch } from "@/features/profile/hooks/useProfileFetch";
 import { ProfileDataSection } from "@/features/profile/components/ProfileDataSection";
 import CommentList from "./comment/list";
 
-export function ProfileCommentHistory() {
+export function ProfileCommentHistory({ initialComments }: { initialComments?: ProfileComment[] }) {
   const { data: comments, isLoading, error } = useProfileFetch<ProfileComment>(
     fetchProfileComments,
     "Unable to load comment history.",
+    initialComments,
   );
 
   return (

--- a/apps/web/src/features/profile/components/ProfileHead.tsx
+++ b/apps/web/src/features/profile/components/ProfileHead.tsx
@@ -1,17 +1,11 @@
-import { useCurrentSession } from '@/features/auth/session';
+import type { PrivateProfile } from '@/features/profile/profileTypes';
 
-export function ProfileHead() {
-  const { user, isLoading } = useCurrentSession();
-
-  if (isLoading) {
-    return <div className="shell"><div className="profile-head" /></div>;
-  }
-
-  const displayName = user?.display_name ?? user?.handle?.replace(/^@/, '') ?? 'User';
-  const handle = user?.handle ?? '';
+export function ProfileHead({ profile }: { profile: PrivateProfile }) {
+  const displayName = profile.display_name ?? profile.handle?.replace(/^@/, '') ?? 'User';
+  const handle = profile.handle ?? '';
   const avatarInitial = displayName.charAt(0).toUpperCase();
-  const memberSince = user?.created_at
-    ? new Date(user.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+  const memberSince = profile.created_at
+    ? new Date(profile.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     : null;
 
   const metaItems = [

--- a/apps/web/src/features/profile/components/ProfilePage.tsx
+++ b/apps/web/src/features/profile/components/ProfilePage.tsx
@@ -22,20 +22,20 @@ import { ProfilePlaceholder } from "@/features/profile/components/ProfilePlaceho
 import { FormMessage } from "@/components/ui/FormMessage";
 
 export function ProfilePage({
+  initialProfile,
   onProfileChange,
 }: {
+  initialProfile?: PrivateProfile;
   onProfileChange?: (p: PrivateProfile) => void;
 }) {
   const { refreshSession } = useCurrentSession();
   const [errors, setErrors] = useState<ProfileFormErrors>({});
-  const [fields, setFields] = useState<ProfileFormFields>({
-    display_name: "",
-    first_name: "",
-    last_name: "",
-  });
-  const [isLoading, setIsLoading] = useState(true);
+  const [fields, setFields] = useState<ProfileFormFields>(
+    initialProfile ? fieldsFromProfile(initialProfile) : { display_name: "", first_name: "", last_name: "" },
+  );
+  const [isLoading, setIsLoading] = useState(!initialProfile);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [profile, setProfile] = useState<PrivateProfile | null>(null);
+  const [profile, setProfile] = useState<PrivateProfile | null>(initialProfile ?? null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const loadProfile = useCallback(async () => {
@@ -57,8 +57,9 @@ export function ProfilePage({
   }, []);
 
   useEffect(() => {
+    if (initialProfile) return;
     void loadProfile();
-  }, [loadProfile]);
+  }, [initialProfile, loadProfile]);
 
   function handleChange(field: keyof ProfileFormFields, value: string) {
     setFields((currentFields) => ({

--- a/apps/web/src/features/profile/components/ProfileRecentlyViewed.tsx
+++ b/apps/web/src/features/profile/components/ProfileRecentlyViewed.tsx
@@ -3,10 +3,11 @@ import { fetchReadingHistory } from "@/features/profile/api/profileApi";
 import { useProfileFetch } from "@/features/profile/hooks/useProfileFetch";
 import { ProfileDataSection } from "@/features/profile/components/ProfileDataSection";
 
-export function ProfileRecentlyViewed() {
+export function ProfileRecentlyViewed({ initialHistory }: { initialHistory?: ProfileReadingHistoryItem[] }) {
   const { data: history, isLoading, error } = useProfileFetch<ProfileReadingHistoryItem>(
     fetchReadingHistory,
     "Unable to load reading history.",
+    initialHistory,
   );
 
   return (

--- a/apps/web/src/features/profile/hooks/useProfileFetch.ts
+++ b/apps/web/src/features/profile/hooks/useProfileFetch.ts
@@ -15,6 +15,8 @@ export function useProfileFetch<T>(
   const fetcherRef = useRef(fetcher);
   const errorRef = useRef(errorMessage);
   const mountedRef = useRef(true);
+  // Captured at mount — immune to referential instability of the initialData array.
+  const skipFetchRef = useRef(initialData !== undefined);
 
   const load = useCallback(async () => {
     try {
@@ -30,11 +32,11 @@ export function useProfileFetch<T>(
   }, []);
 
   useEffect(() => {
-    if (initialData) return;
+    if (skipFetchRef.current) return;
     mountedRef.current = true;
     void load();
     return () => { mountedRef.current = false; };
-  }, [load, initialData]);
+  }, [load]);
 
   return { data, isLoading, error };
 }

--- a/apps/web/src/features/profile/hooks/useProfileFetch.ts
+++ b/apps/web/src/features/profile/hooks/useProfileFetch.ts
@@ -6,9 +6,10 @@ import { logError } from "@/lib/utils/logError";
 export function useProfileFetch<T>(
   fetcher: (token: string) => Promise<T[]>,
   errorMessage: string,
+  initialData?: T[],
 ) {
-  const [data, setData] = useState<T[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [data, setData] = useState<T[]>(initialData ?? []);
+  const [isLoading, setIsLoading] = useState(!initialData);
   const [error, setError] = useState<string | null>(null);
 
   const fetcherRef = useRef(fetcher);
@@ -29,10 +30,11 @@ export function useProfileFetch<T>(
   }, []);
 
   useEffect(() => {
+    if (initialData) return;
     mountedRef.current = true;
     void load();
     return () => { mountedRef.current = false; };
-  }, [load]);
+  }, [load, initialData]);
 
   return { data, isLoading, error };
 }

--- a/apps/web/src/features/profile/profileTypes.ts
+++ b/apps/web/src/features/profile/profileTypes.ts
@@ -87,3 +87,9 @@ export type ProfileReadingHistoryResponse = {
 export type DeleteAccountResponse = {
   message: string;
 };
+
+export type ProfilePageData = {
+  profile: PrivateProfile;
+  comments: ProfileComment[];
+  readingHistory: ProfileReadingHistoryItem[];
+};

--- a/apps/web/src/lib/auth/supabaseClient.ts
+++ b/apps/web/src/lib/auth/supabaseClient.ts
@@ -1,9 +1,12 @@
-import { createClient } from '@supabase/supabase-js';
+import { createBrowserClient } from '@supabase/ssr';
 
-export const supabase = createClient(
-    import.meta.env.VITE_SUPABASE_URL,
-    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY,
+export const supabase = createBrowserClient(
+    import.meta.env.VITE_SUPABASE_URL as string,
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string,
     {
-        auth: { detectSessionInUrl: false, flowType: 'pkce' },
+        auth: {
+            detectSessionInUrl: false,
+            flowType: 'pkce',
+        },
     },
 );

--- a/apps/web/src/lib/auth/supabaseServerClient.ts
+++ b/apps/web/src/lib/auth/supabaseServerClient.ts
@@ -1,0 +1,22 @@
+import { createServerClient, parseCookieHeader } from '@supabase/ssr';
+
+export function createSupabaseServerClient(headers: Record<string, string> | null | undefined) {
+  const cookieHeader = headers?.['cookie'] ?? '';
+  const cookies = parseCookieHeader(cookieHeader);
+
+  return createServerClient(
+    import.meta.env.VITE_SUPABASE_URL as string,
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string,
+    {
+      cookies: {
+        getAll() {
+          return cookies
+            .filter((c): c is { name: string; value: string } => c.value !== undefined);
+        },
+        setAll() {
+          // read-only in guard context — token refresh happens on the browser client
+        },
+      },
+    },
+  );
+}

--- a/apps/web/src/vike.d.ts
+++ b/apps/web/src/vike.d.ts
@@ -6,8 +6,6 @@ declare global {
         handle: string | null;
         isAdmin: boolean;
       } | null;
-      // Server-side only — not in passToClient. Used by +data.ts to avoid a second session read.
-      userAccessToken?: string | null;
     }
   }
 }

--- a/apps/web/src/vike.d.ts
+++ b/apps/web/src/vike.d.ts
@@ -6,6 +6,8 @@ declare global {
         handle: string | null;
         isAdmin: boolean;
       } | null;
+      // Server-side only — not in passToClient. Used by +data.ts to avoid a second session read.
+      userAccessToken?: string | null;
     }
   }
 }

--- a/apps/web/src/vike.d.ts
+++ b/apps/web/src/vike.d.ts
@@ -1,0 +1,13 @@
+declare global {
+  namespace Vike {
+    interface PageContext {
+      initialUser?: {
+        displayName: string | null;
+        handle: string | null;
+        isAdmin: boolean;
+      } | null;
+    }
+  }
+}
+
+export {};

--- a/docs/architecture/profile-page.md
+++ b/docs/architecture/profile-page.md
@@ -58,19 +58,31 @@ This document defines the structure, data flow, and implementation status for th
                                            signOut throws; notify field assertions in
                                            ProfileNotificationTest; ProfileService::deleteAccount
                                            wrapped in DB::transaction
+19. SSR auth guard                   done — @supabase/ssr installed; pages/(user)/+guard.ts reads
+                                           session cookie server-side and redirects guests before
+                                           HTML is rendered; pages/(user)/+config.ts sets
+                                           prerender: false; RequireAuth removed from layout
+20. SSR data fetching                done — pages/(user)/profile/+data.ts fetches profile, comments,
+                                           and reading-history in parallel server-side; ProfilePage,
+                                           ProfileCommentHistory, ProfileRecentlyViewed accept
+                                           initialX props; useProfileFetch hook accepts initialData;
+                                           ProfileHead accepts profile prop; zero loading flash on /profile
+21. SSR header                       done — pages/+onBeforeRender.ts runs on every request, calls
+                                           GET /api/v1/session, puts initialUser into pageContext;
+                                           passToClient: ['initialUser'] in root +config.ts;
+                                           Header reads pageContext.initialUser via usePageContext()
+                                           so it renders with correct auth state on first HTML response
 ```
 
 ## Route and Auth
 
-The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group layout (`pages/(user)/+Layout.tsx`) wraps every page in this group with:
+The page lives at `pages/(user)/profile/+Page.tsx`. Auth is enforced at the server level:
 
-```tsx
-<AppShell>
-  <RequireAuth>{children}</RequireAuth>
-</AppShell>
-```
+- `pages/(user)/+guard.ts` — reads the Supabase session cookie via `createSupabaseServerClient`, redirects guests to `/signin` before any HTML is rendered (HTTP 302, no client JS needed)
+- `pages/(user)/+config.ts` — sets `prerender: false` so the guard runs at request time, not at build time
+- `pages/(user)/+Layout.tsx` — wraps children in `<AppShell>` only; no client-side auth wrapper
 
-`RequireAuth` redirects unauthenticated visitors to `/signin`. The page itself does not repeat the auth guard.
+The page itself does not repeat the auth check.
 
 ## Page Structure
 
@@ -95,19 +107,20 @@ The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group lay
 ### ProfileHead
 
 - Source: `src/features/profile/components/ProfileHead.tsx`
-- Data: `useCurrentSession().user` — `display_name`, `handle`, `created_at`
+- Data: `profile: PrivateProfile` prop passed from `+Page.tsx` (SSR data from `+data.ts`)
 - Renders the page header with initials avatar, display name, handle, and member-since date.
 - `avatar_url` has been fully removed — initials fallback is always shown.
-- `created_at` is included in the session response (`SessionResource`) so no extra fetch is needed.
+- No loading state — renders immediately from SSR data on first HTML response.
 
 ### ProfilePage (account form)
 
 - Source: `src/features/profile/components/ProfilePage.tsx`
-- API: `GET /api/v1/profile` → `fetchPrivateProfile`, `PATCH /api/v1/profile` → `updatePrivateProfile`
+- Data: `initialProfile: PrivateProfile` prop from `+Page.tsx` (SSR); no initial fetch needed
+- API: `PATCH /api/v1/profile` → `updatePrivateProfile` (mutation only)
 - Fields: `display_name`, `first_name`, `last_name`
 - Read-only display: `email` (read from `useCurrentSession()`, never from the profile API)
 - Calls `refreshSession()` after a successful update so the header reflects name changes immediately.
-- Error state shows a "Try again" retry button; loading state shows a placeholder.
+- Error state shows a "Try again" retry button which triggers a client-side re-fetch.
 
 ### ProfilePasswordSection
 
@@ -121,15 +134,17 @@ The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group lay
 ### ProfileCommentHistory
 
 - Source: `src/features/profile/components/ProfileCommentHistory.tsx`
-- API: `GET /api/v1/profile/comments` via `fetchProfileComments`
-- Uses `useProfileFetch` hook + `ProfileDataSection` for all four states (loading / error / empty / data).
+- Data: `initialComments: ProfileComment[]` prop from `+Page.tsx` (SSR); no initial fetch needed
+- API: `GET /api/v1/profile/comments` via `fetchProfileComments` (used only on error-recovery path)
+- Uses `useProfileFetch` hook (with `initialData` param) + `ProfileDataSection` for all four states.
 - Backend returns at most 10 comments ordered by latest, eager-loading the related post.
 
 ### ProfileRecentlyViewed
 
 - Source: `src/features/profile/components/ProfileRecentlyViewed.tsx`
-- API: `GET /api/v1/profile/reading-history` via `fetchReadingHistory`
-- Uses `useProfileFetch` hook + `ProfileDataSection` for all four states.
+- Data: `initialHistory: ProfileReadingHistoryItem[]` prop from `+Page.tsx` (SSR); no initial fetch needed
+- API: `GET /api/v1/profile/reading-history` via `fetchReadingHistory` (used only on error-recovery path)
+- Uses `useProfileFetch` hook (with `initialData` param) + `ProfileDataSection` for all four states.
 - Each item shows post title, last-viewed date, and a horizontal read-progress bar.
 - Backend returns at most 10 items ordered by `last_viewed_at` desc.
 
@@ -159,7 +174,7 @@ The page lives at `pages/(user)/profile/+Page.tsx`. The `(user)` route group lay
 | `ProfileSection` | `src/features/profile/components/ProfileSection.tsx` | `div.profile-section` wrapper with optional `h2` |
 | `ProfilePlaceholder` | `src/features/profile/components/ProfilePlaceholder.tsx` | Muted placeholder text for loading/empty/error states |
 | `ProfileDataSection` | `src/features/profile/components/ProfileDataSection.tsx` | Combines ProfileSection + ProfilePlaceholder for all four async states |
-| `useProfileFetch` | `src/features/profile/hooks/useProfileFetch.ts` | Shared fetch lifecycle: token → API call → state; `mountedRef` prevents post-unmount updates |
+| `useProfileFetch` | `src/features/profile/hooks/useProfileFetch.ts` | Shared fetch lifecycle: token → API call → state; accepts optional `initialData` to skip initial fetch when SSR data is provided; `mountedRef` prevents post-unmount updates |
 
 ## API Touchpoints
 
@@ -215,7 +230,9 @@ Profile page styles live in `src/features/profile/profile.css`.
 
 ## Acceptance Checks
 
-- Signed-out users visiting `/profile` are redirected to `/signin`.
+- Signed-out users visiting `/profile` receive an HTTP 302 redirect to `/signin` server-side — no HTML is rendered, no client JS runs.
+- Hard refresh on `/profile` renders the full page (header, profile form, comment history, reading history) with real data on the first HTML response — no loading spinners visible.
+- Viewing page source (`view-source:`) confirms profile data (display name, comment body text, post titles) is present in the HTML, not injected client-side.
 - Signed-in users see their initials avatar, display name, handle, and member-since date.
 - Account form pre-fills from `GET /api/v1/profile`; saving updates the API and refreshes the header.
 - Password change re-authenticates via Supabase, updates credentials, signs out, and redirects to `/signin`.

--- a/docs/architecture/supabase-ssr-auth.md
+++ b/docs/architecture/supabase-ssr-auth.md
@@ -51,21 +51,29 @@ Target:
 ## Key Files
 
 ```text
-apps/web/src/lib/auth/supabaseClient.ts          — current browser client (replace with SSR-aware client)
-apps/web/src/features/auth/guards/AuthGuard.tsx  — client-side guard (to be replaced by +guard.ts)
-apps/web/src/features/auth/guards/RequireAuth.tsx
-apps/web/src/features/auth/guards/RequireGuest.tsx
-apps/web/pages/(user)/+Layout.tsx
-apps/web/pages/(auth)/+Layout.tsx
-apps/web/pages/(user)/+guard.ts                  — new file
-apps/web/pages/(auth)/+guard.ts                  — new file
+apps/web/src/lib/auth/supabaseClient.ts          — browser client (createBrowserClient from @supabase/ssr)
+apps/web/src/lib/auth/supabaseServerClient.ts    — server client factory (read-only cookie adapter)
+apps/web/src/features/auth/guards/AuthGuard.tsx  — @deprecated, replaced by +guard.ts
+apps/web/src/features/auth/guards/RequireAuth.tsx — @deprecated, replaced by +guard.ts
+apps/web/src/features/auth/guards/RequireGuest.tsx — @deprecated, replaced by +guard.ts
+apps/web/pages/(user)/+Layout.tsx               — wraps in AppShell only, no auth wrapper
+apps/web/pages/(auth)/+Layout.tsx               — wraps in AuthShell only, no auth wrapper
+apps/web/pages/(user)/+guard.ts                 — server-side auth gate for protected routes
+apps/web/pages/(auth)/+guard.ts                 — server-side guest gate for auth routes
+apps/web/pages/(user)/+config.ts                — prerender: false (required for guards)
+apps/web/pages/(auth)/+config.ts                — prerender: false (required for guards)
+apps/web/pages/(user)/profile/+data.ts          — SSR data fetch: profile + comments + reading-history
+apps/web/pages/+onBeforeRender.ts               — global SSR hook: GET /api/v1/session → pageContext.initialUser
+apps/web/pages/+config.ts                       — passToClient: ['initialUser']
+apps/web/src/vike.d.ts                          — Vike PageContext type augmentation
 ```
 
 ## Acceptance Checks
 
-- Hard refresh on `/profile` renders the page immediately — no "Checking your session..." flash.
-- Guest visiting `/profile` is redirected to `/signin` via HTTP 302 (server-side, before HTML is sent).
+- Hard refresh on `/profile` renders the full page — header with avatar, account form, comment history, reading history — with zero loading flash. All content present in view-source HTML.
+- Guest visiting `/profile` is redirected to `/signin` via HTTP 302 (server-side, before HTML is sent) — visible in DevTools Network tab as a 302 response with no HTML body.
 - Signed-in user visiting `/signin` is redirected to `/` server-side.
-- OAuth callback (`/auth/callback`) correctly sets the session cookie after sign-in.
+- Main site header renders with correct avatar initial, display name, and account menu on first HTML response across all pages — no blank span flash on any page.
+- OAuth callback (`/auth/callback`) correctly sets the session cookie after sign-in. (pending verification)
 - Token refresh works transparently — expired tokens are refreshed via the cookie flow.
 - All existing profile page features continue to work (account form, notifications, delete, etc.).

--- a/docs/architecture/supabase-ssr-auth.md
+++ b/docs/architecture/supabase-ssr-auth.md
@@ -1,0 +1,71 @@
+# Supabase SSR Auth
+
+## Purpose
+
+Migrate the frontend from `supabase-js` localStorage-based sessions to `@supabase/ssr` cookie-based sessions, enabling true server-side auth gating in Vike via `+guard.ts` files.
+
+- Eliminates the "Checking your session..." loading flash on hard refresh.
+- Enables PHP-style server-side auth gates: Vercel SSR validates the session before rendering any protected page.
+- Required before production deployment on Vercel — localStorage is client-only and cannot be read during SSR.
+
+## Deployment Context
+
+- **Frontend:** Vercel (Vike + React SSR, Node.js serverless)
+- **Backend:** Render (Laravel 12 JSON API, JWT auth via Supabase JWKS)
+- **Auth:** Supabase (currently localStorage, migrating to cookies)
+
+## Implementation Progress
+
+```text
+1. @supabase/ssr setup         done — @supabase/ssr@0.10.3 installed, supabaseClient.ts replaced with
+                               createBrowserClient, supabaseServerClient.ts factory created with
+                               getAll/setAll cookie adapter (read-only in guard context)
+2. Server-side guards          done — pages/(user)/+guard.ts redirects guests to /signin server-side,
+                               pages/(auth)/+guard.ts redirects authenticated users to / with /reset-password
+                               bypass; RequireAuth/RequireGuest removed from layouts; guards marked @deprecated
+3. Prerender config            done — prerender: false in pages/(user)/+config.ts and pages/(auth)/+config.ts
+                               so guards run at request time not build time
+4. Session context update      done — CurrentSessionProvider uses same supabase import; createBrowserClient
+                               reads cookies on INITIAL_SESSION, eliminating localStorage loading flash
+5. Server-side data fetching   done — pages/(user)/profile/+data.ts fetches profile, comments, and
+                               reading-history in parallel server-side; components accept initialX props;
+                               useProfileFetch hook accepts initialData; zero loading flash on /profile
+6. Auth callback update        pending — verify /auth/callback sets cookies correctly post-OAuth
+7. Tests and verification      pending — manual verification of no loading flash, correct server redirects,
+                               cookie persistence after OAuth
+```
+
+## Route and Auth
+
+Current:
+- `pages/(user)/+Layout.tsx` wraps children in `<RequireAuth>` (client-side guard)
+- `pages/(auth)/+Layout.tsx` wraps children in `<RequireGuest>` (client-side guard)
+- Session stored in localStorage by Supabase default
+
+Target:
+- `pages/(user)/+guard.ts` — server-side guard, reads session cookie, redirects to `/signin` if invalid
+- `pages/(auth)/+guard.ts` — server-side guard, reads session cookie, redirects to `/` if already authenticated
+- Session stored in cookies by `@supabase/ssr`
+- `RequireAuth` and `RequireGuest` components removed or kept as fallback only
+
+## Key Files
+
+```text
+apps/web/src/lib/auth/supabaseClient.ts          — current browser client (replace with SSR-aware client)
+apps/web/src/features/auth/guards/AuthGuard.tsx  — client-side guard (to be replaced by +guard.ts)
+apps/web/src/features/auth/guards/RequireAuth.tsx
+apps/web/src/features/auth/guards/RequireGuest.tsx
+apps/web/pages/(user)/+Layout.tsx
+apps/web/pages/(auth)/+Layout.tsx
+apps/web/pages/(user)/+guard.ts                  — new file
+apps/web/pages/(auth)/+guard.ts                  — new file
+```
+
+## Acceptance Checks
+
+- Hard refresh on `/profile` renders the page immediately — no "Checking your session..." flash.
+- Guest visiting `/profile` is redirected to `/signin` via HTTP 302 (server-side, before HTML is sent).
+- Signed-in user visiting `/signin` is redirected to `/` server-side.
+- OAuth callback (`/auth/callback`) correctly sets the session cookie after sign-in.
+- Token refresh works transparently — expired tokens are refreshed via the cookie flow.
+- All existing profile page features continue to work (account form, notifications, delete, etc.).

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -60,9 +60,11 @@ Every route must have at minimum:
 
 ### Route guards
 
-- All pages under `pages/(user)/` are wrapped by `RequireAuth` via `pages/(user)/+Layout.tsx`. Do not add a second auth check inside individual page components.
-- All pages under `pages/(auth)/` are wrapped by `RequireGuest` via `pages/(auth)/+Layout.tsx`. Do not render auth forms if the user is already signed in.
-- Admin UI must check the `isAdmin` flag from `useCurrentSession()` to hide admin-only controls, but the real gate is always the `admin` middleware server-side. Never rely on a client-side role check as the sole protection.
+- All pages under `pages/(user)/` are protected by `pages/(user)/+guard.ts` — a server-side Vike guard that reads the Supabase session cookie and redirects guests to `/signin` before any HTML is rendered.
+- All pages under `pages/(auth)/` are protected by `pages/(auth)/+guard.ts` — redirects authenticated users to `/`. The `/reset-password` path is bypassed because the recovery token flow fires `SIGNED_IN`.
+- Do not add a second auth check inside individual page components — the guard runs before the page renders.
+- `RequireAuth` and `RequireGuest` components are deprecated. Do not use them in new pages.
+- Admin UI must check the `isAdmin` flag from `useCurrentSession()` or `pageContext.initialUser.isAdmin` to hide admin-only controls, but the real gate is always the `admin` middleware server-side. Never rely on a client-side role check as the sole protection.
 
 ### Access token handling
 
@@ -97,7 +99,8 @@ Use this checklist when a planning agent decomposes a new feature. Add items her
 - [ ] Are guest / auth / admin behavior tests written?
 
 ### New frontend page or form
-- [ ] Is the page in the correct route group with the right layout guard?
+- [ ] Is the page in the correct route group with a `+guard.ts` server-side guard?
+- [ ] If the route group has a guard, does it also have `prerender: false` in `+config.ts`?
 - [ ] Does the form validate client-side before calling the API?
 - [ ] Are error messages user-friendly (no raw API errors rendered)?
 - [ ] Are tokens fetched via `supabase.auth.getSession()` immediately before use?
@@ -110,3 +113,4 @@ Use this checklist when a planning agent decomposes a new feature. Add items her
 Update this section when new security conventions are added:
 
 - **2026-05-07** — Initial doc. Covers profile page, auth flow, and current route structure.
+- **2026-05-08** — Updated route guards: `RequireAuth`/`RequireGuest` replaced by `+guard.ts` server-side guards. Added `prerender: false` requirement and admin `isAdmin` source clarification.


### PR DESCRIPTION
## Summary

- Add Vike `+guard.ts` server-side auth gates for `(user)` and `(auth)` route groups
- Add global `+onBeforeRender.ts` — reads Supabase session on every SSR request, sets `initialUser` on `pageContext` to eliminate the header auth-loading flash
- Add `(user)/profile/+data.ts` — profile, comments, and reading history all fetched server-side; components receive `initialX` props and skip client-side fetch on first load
- Add `supabaseServerClient.ts` (read-only `@supabase/ssr` server client)
- Make `ProfileHead` accept a `profile` prop instead of calling `useCurrentSession()`
- Fix: `data()` runs before `onBeforeRender()` in Vike — `+data.ts` reads the session cookie directly (relying on `pageContext.userAccessToken` set by `onBeforeRender` would always be undefined)

## Key decisions

- Three independent session reads per profile-page request (guard, data, onBeforeRender) — required by Vike's hook order; sharing the token between hooks is impossible without a custom server
- `passToClient: ['initialUser']` only — access tokens never reach the client bundle
- `Promise.allSettled` in `+data.ts` so comments/history failure doesn't break the whole profile page

## Test plan

- [ ] Sign in → navigate to `/profile` — page loads with SSR data, no loading flash
- [ ] DevTools Network: no `/api/v1/profile*` requests on first load (served from SSR)
- [ ] Navigate away and back — client nav works, components refetch correctly
- [ ] Sign out → navigate to `/profile` — redirects to `/signin`
- [ ] Signed in → navigate to `/signin` — redirects to `/`
- [ ] Header shows correct name immediately on SSR (no flash)
- [ ] `npm run typecheck` passes