### PR TITLE
fix - show guest CTA immediately when server confirms no session

### DIFF
--- a/apps/web/src/components/layout/Header/Header.tsx
+++ b/apps/web/src/components/layout/Header/Header.tsx
@@ -28,7 +28,9 @@ export function Header() {
   const { isLoading: sessionLoading, isAuthenticated, isAdmin, user, signOut } =
     useCurrentSession();
 
-  const isLoading = sessionLoading && !initialUser;
+  // initialUser === null means the server confirmed guest — no need to wait for INITIAL_SESSION.
+  // initialUser === undefined means the server didn't resolve auth (shouldn't happen in practice).
+  const isLoading = sessionLoading && initialUser === undefined;
 
   const guestCta =
     pathname === headerAuthButtons.signIn.href


### PR DESCRIPTION
isLoading was checking !initialUser, treating null (server-confirmed guest) the same as undefined (unresolved). Changed to initialUser === undefined so the Sign In button renders in SSR HTML and never pops in after hydration.