### PR TITLE
feat - port resume theme and redesign header UI

### DIFF
--- a/apps/web/src/components/common/MaintenancePage.tsx
+++ b/apps/web/src/components/common/MaintenancePage.tsx
@@ -1,5 +1,6 @@
 import { Moon, Sun } from "lucide-react";
 
+import { Brand } from "@/components/ui/Brand";
 import { useThemeMode } from "@/lib/theme/useThemeMode";
 
 export function MaintenancePage() {
@@ -9,10 +10,7 @@ export function MaintenancePage() {
     <div className="min-h-screen grid grid-rows-[auto_1fr_auto] bg-paper text-ink">
       <div className="border-b border-rule px-8 py-6">
         <div className="shell">
-          <a href="/" className="brand inline-flex items-center gap-2 no-underline text-ink font-semibold">
-            <span className="brand-mark">j</span>
-            <span>jymb<span className="text-accent">.</span>blog</span>
-          </a>
+          <Brand href="/" />
         </div>
       </div>
 

--- a/apps/web/src/components/layout/Footer/Footer.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { Brand } from "@/components/ui/Brand";
 import { footerLinkGroups } from "@/components/layout/Footer/footerNavItems";
 
 export function Footer() {
@@ -6,17 +7,7 @@ export function Footer() {
       <div className="shell">
         <div className="footer-grid">
           <div>
-            <a
-              className="mb-3 flex items-center gap-2 font-mono text-sm font-semibold"
-              href="/"
-            >
-              <span className="grid size-[22px] place-items-center rounded-brand-sm bg-ink text-xs font-bold text-paper">
-                J
-              </span>
-              <span>
-                jymb<span className="text-accent-ink">.</span>blog
-              </span>
-            </a>
+            <Brand href="/" className="mb-3" />
             <p className="m-0 max-w-[36ch] font-serif text-sm leading-6">
               A small, slow blog about building software thoughtfully.
               Hand-coded. No trackers. No popups.

--- a/apps/web/src/components/layout/Header/Header.tsx
+++ b/apps/web/src/components/layout/Header/Header.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
+import { ArrowRight, LayoutDashboard, LogOut, User } from "lucide-react";
 import { usePageContext } from "vike-react/usePageContext";
 
 import {
+  HeaderMobileAccountPanel,
   HeaderMobileMenuButton,
   HeaderMobileMenuPanel,
 } from "@/components/layout/Header/HeaderMobileMenu";
@@ -13,6 +15,7 @@ import {
 } from "@/components/layout/Header/headerNavItem";
 import type { HeaderActionItem } from "@/components/layout/Header/headerTypes";
 
+import { Brand } from "@/components/ui/Brand";
 import { useCurrentSession } from "@/features/auth/session/useCurrentSession";
 import { useThemeMode } from "@/lib/theme/useThemeMode";
 
@@ -28,8 +31,6 @@ export function Header() {
   const { isLoading: sessionLoading, isAuthenticated, isAdmin, user, signOut } =
     useCurrentSession();
 
-  // initialUser === null means the server confirmed guest — no need to wait for INITIAL_SESSION.
-  // initialUser === undefined means the server didn't resolve auth (shouldn't happen in practice).
   const isLoading = sessionLoading && initialUser === undefined;
 
   const guestCta =
@@ -97,23 +98,13 @@ export function Header() {
         aria-label="Primary"
         className="shell flex h-16 items-center justify-between gap-8"
       >
-        <a
-          className="flex items-center gap-2 font-mono text-sm font-semibold"
-          href="/"
-        >
-          <span className="grid size-[22px] place-items-center rounded-brand-sm bg-ink text-xs font-bold text-paper">
-            J
-          </span>
-          <span>
-            jymb<span className="text-accent-ink">.</span>blog
-          </span>
-        </a>
+        <Brand href="/" />
 
         <div className="flex items-center gap-2">
           {headerNavItems.map((item) => (
             <a
               key={item.href}
-              className="btn btn-ghost hidden md:inline-flex"
+              className={`nav-link hidden md:inline-flex ${pathname === item.href ? "active" : ""}`}
               href={item.href}
             >
               {item.label}
@@ -138,8 +129,8 @@ export function Header() {
                 aria-expanded={isAccountMenuOpen}
                 aria-haspopup="menu"
                 aria-label="Open account menu"
-                className="btn btn-ghost size-10 p-0"
-                onClick={() => setIsAccountMenuOpen((isOpen) => !isOpen)}
+                className="btn btn-ghost size-10 border-0 p-0"
+                onClick={() => setIsAccountMenuOpen((v) => !v)}
                 type="button"
               >
                 <span className="grid size-7 place-items-center rounded-full bg-ink text-xs font-semibold uppercase text-paper">
@@ -150,42 +141,77 @@ export function Header() {
               {isAccountMenuOpen ? (
                 <div
                   aria-label="Account menu"
-                  className="absolute right-0 top-[calc(100%+0.5rem)] min-w-56 rounded-brand-sm border border-rule bg-paper p-2 shadow-lg"
+                  className="absolute right-0 top-[calc(100%+0.5rem)] min-w-52 overflow-hidden rounded-brand bg-paper-2 shadow-xl"
                   role="menu"
                 >
-                  <div className="border-b border-rule px-3 py-2">
-                    <div className="text-sm font-semibold text-ink">
-                      {accountName}
-                    </div>
-                    <div className="mt-0.5 text-xs text-muted">
-                      {accountHandle}
+                  <div className="h-0.5 bg-accent" />
+
+                  <div className="flex items-center gap-3 px-4 py-3.5">
+                    <span className="grid size-8 shrink-0 place-items-center rounded-full bg-ink text-xs font-semibold uppercase text-paper">
+                      {avatarInitial}
+                    </span>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold text-ink">
+                        {accountName}
+                      </div>
+                      <div className="truncate text-xs text-ink-4">
+                        {accountHandle}
+                      </div>
                     </div>
                   </div>
 
-                  {actions.map((action) =>
-                    action.type === "link" ? (
-                      <a
-                        key={action.href}
-                        className="btn btn-ghost w-full justify-start"
-                        href={action.href}
-                        onClick={() => setIsAccountMenuOpen(false)}
-                        role="menuitem"
-                      >
-                        {action.label}
-                      </a>
-                    ) : (
-                      <button
-                        key={action.label}
-                        className="btn btn-ghost w-full justify-start"
-                        disabled={action.disabled}
-                        onClick={() => void action.onClick()}
-                        role="menuitem"
-                        type="button"
-                      >
-                        {action.label}
-                      </button>
-                    ),
-                  )}
+                  <div className="px-1.5 pb-1.5">
+                    {actions.map((action) => {
+                      const Icon =
+                        action.label === "Dashboard"
+                          ? LayoutDashboard
+                          : action.label === "Profile"
+                            ? User
+                            : LogOut;
+                      const isDestructive = action.label === "Sign out";
+
+                      return action.type === "link" ? (
+                        <a
+                          key={action.href}
+                          className="group flex w-full items-center gap-2.5 rounded-brand-sm px-3 py-2.5 text-sm text-ink-3 transition-colors hover:bg-paper-3 hover:text-ink"
+                          href={action.href}
+                          onClick={() => setIsAccountMenuOpen(false)}
+                          role="menuitem"
+                        >
+                          <Icon
+                            aria-hidden="true"
+                            className="size-3.5 shrink-0 transition-colors group-hover:text-accent-ink"
+                          />
+                          <span className="flex-1">{action.label}</span>
+                          <ArrowRight
+                            aria-hidden="true"
+                            className="size-3 opacity-0 transition-all group-hover:translate-x-0.5 group-hover:opacity-50"
+                          />
+                        </a>
+                      ) : (
+                        <button
+                          key={action.label}
+                          className={`group flex w-full items-center gap-2.5 rounded-brand-sm px-3 py-2.5 text-sm transition-colors disabled:opacity-50 ${
+                            isDestructive
+                              ? "text-ink-3 hover:bg-red-500/10 hover:text-red-400"
+                              : "text-ink-3 hover:bg-paper-3 hover:text-ink"
+                          }`}
+                          disabled={action.disabled}
+                          onClick={() => void action.onClick()}
+                          role="menuitem"
+                          type="button"
+                        >
+                          <Icon
+                            aria-hidden="true"
+                            className={`size-3.5 shrink-0 transition-colors ${
+                              isDestructive ? "group-hover:text-red-400" : "group-hover:text-accent-ink"
+                            }`}
+                          />
+                          <span className="flex-1 text-left">{action.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
               ) : null}
             </div>
@@ -210,10 +236,10 @@ export function Header() {
               aria-expanded={isMobileAccountMenuOpen}
               aria-haspopup="menu"
               aria-label="Open account menu"
-              className="btn btn-ghost size-10 p-0 md:hidden"
+              className="btn btn-ghost size-10 border-0 p-0 md:hidden"
               onClick={() => {
                 setIsMobileMenuOpen(false);
-                setIsMobileAccountMenuOpen((isOpen) => !isOpen);
+                setIsMobileAccountMenuOpen((v) => !v);
               }}
               type="button"
             >
@@ -227,54 +253,22 @@ export function Header() {
             isOpen={isMobileMenuOpen}
             onToggle={() => {
               setIsMobileAccountMenuOpen(false);
-              setIsMobileMenuOpen((isOpen) => !isOpen);
+              setIsMobileMenuOpen((v) => !v);
             }}
           />
         </div>
       </nav>
 
       {isMobileAccountMenuOpen ? (
-        <div
-          aria-label="Account menu"
-          className="absolute left-0 top-full w-full border-t border-rule bg-paper shadow-lg md:hidden"
-          role="menu"
-        >
-          <div className="shell py-3">
-            <div className="border-b border-rule px-3 pb-3">
-              <div className="text-sm font-semibold text-ink">
-                {accountName}
-              </div>
-              <div className="mt-0.5 text-xs text-muted">{accountHandle}</div>
-            </div>
-
-            <div className="grid gap-1 pt-3">
-              {actions.map((action) =>
-                action.type === "link" ? (
-                  <a
-                    key={action.href}
-                    className="btn btn-ghost justify-start"
-                    href={action.href}
-                    onClick={() => setIsMobileAccountMenuOpen(false)}
-                    role="menuitem"
-                  >
-                    {action.label}
-                  </a>
-                ) : (
-                  <button
-                    key={action.label}
-                    className="btn btn-ghost justify-start"
-                    disabled={action.disabled}
-                    onClick={() => void action.onClick()}
-                    role="menuitem"
-                    type="button"
-                  >
-                    {action.label}
-                  </button>
-                ),
-              )}
-            </div>
-          </div>
-        </div>
+        <HeaderMobileAccountPanel
+          accountHandle={accountHandle}
+          accountName={accountName}
+          actions={actions}
+          avatarInitial={avatarInitial}
+          onClose={() => setIsMobileAccountMenuOpen(false)}
+          onToggleThemeMode={toggleThemeMode}
+          themeMode={themeMode}
+        />
       ) : null}
 
       {isMobileMenuOpen ? (
@@ -282,6 +276,9 @@ export function Header() {
           actions={effectiveIsAuthenticated ? [] : actions}
           items={headerNavItems}
           onClose={() => setIsMobileMenuOpen(false)}
+          onToggleThemeMode={toggleThemeMode}
+          pathname={pathname}
+          themeMode={themeMode}
         />
       ) : null}
     </header>

--- a/apps/web/src/components/layout/Header/HeaderMobileMenu.tsx
+++ b/apps/web/src/components/layout/Header/HeaderMobileMenu.tsx
@@ -1,6 +1,11 @@
-import { Menu, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { ArrowRight, Menu, X } from "lucide-react";
 
+import { Brand } from "@/components/ui/Brand";
+import { HeaderThemeToggle } from "@/components/layout/Header/HeaderThemeToggle";
 import type {
+  HeaderMobileAccountPanelProps,
   HeaderMobileMenuButtonProps,
   HeaderMobileMenuPanelProps,
 } from "@/components/layout/Header/headerTypes";
@@ -13,7 +18,7 @@ export function HeaderMobileMenuButton({
     <button
       aria-expanded={isOpen}
       aria-label={isOpen ? "Close menu" : "Open menu"}
-      className="btn btn-ghost size-10 p-0 md:hidden"
+      className="btn btn-ghost size-10 border-0 p-0 md:hidden"
       onClick={onToggle}
       type="button"
     >
@@ -27,56 +32,222 @@ export function HeaderMobileMenuButton({
 }
 
 export function HeaderMobileMenuPanel({
-  actions,
   items,
+  actions,
   onClose,
+  pathname,
+  themeMode,
+  onToggleThemeMode,
 }: HeaderMobileMenuPanelProps) {
-  return (
-    <div className="absolute left-0 top-full w-full border-t border-rule bg-paper shadow-lg md:hidden">
-      <div className="shell py-3">
-        <div className="grid gap-1">
-          {items.map((item) => (
-            <a
-              key={item.href}
-              className="btn btn-ghost justify-start"
-              href={item.href}
-              onClick={onClose}
-            >
-              {item.label}
-            </a>
-          ))}
+  const [mounted, setMounted] = useState(false);
 
-          {actions.map((action) =>
-            action.type === "link" ? (
-              <a
-                key={action.href}
-                className={`btn justify-start ${
-                  action.variant === "primary" ? "btn-primary" : "btn-ghost"
-                }`}
-                href={action.href}
-                onClick={onClose}
-              >
-                {action.label}
-              </a>
-            ) : (
-              <button
-                key={action.label}
-                className={`btn justify-start ${
-                  action.variant === "primary" ? "btn-primary" : "btn-ghost"
-                }`}
-                disabled={action.disabled}
-                onClick={() => {
-                  onClose();
-                  void action.onClick();
-                }}
-                type="button"
-              >
-                {action.label}
-              </button>
-            ),
-          )}
+  useEffect(() => {
+    setMounted(true);
+    document.body.style.overflow = "hidden";
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div className="animate-mobileMenuIn fixed inset-0 z-[60] flex flex-col bg-paper/[0.97] backdrop-blur-xl">
+      {/* grid backdrop */}
+      <div className="pointer-events-none absolute inset-0 grid-bg opacity-20" />
+
+      {/* top bar */}
+      <header className="relative flex items-center justify-between border-b border-rule px-5 py-3">
+        <Brand />
+        <div className="flex items-center gap-1">
+          <HeaderThemeToggle
+            themeMode={themeMode}
+            onToggleThemeMode={onToggleThemeMode}
+          />
+          <button
+            aria-label="Close menu"
+            className="btn btn-ghost size-10 border-0 p-0"
+            onClick={onClose}
+            type="button"
+          >
+            <X aria-hidden="true" className="size-4" />
+          </button>
         </div>
+      </header>
+
+      {/* nav */}
+      <div className="relative flex-1 overflow-y-auto px-5 py-5">
+        <p className="section-eyebrow mb-3">Navigation</p>
+
+        <ul className="flex flex-col">
+          {items.map((item, index) => {
+            const active = pathname === item.href;
+            return (
+              <li
+                key={item.href}
+                className="mobile-menu-item border-b border-rule last:border-b-0"
+                style={{ animationDelay: `${60 + index * 35}ms` }}
+              >
+                <a
+                  className={`group flex items-center gap-3 py-3 text-[15px] font-medium transition-colors ${
+                    active
+                      ? "text-accent-ink"
+                      : "text-ink-2 hover:text-ink"
+                  }`}
+                  href={item.href}
+                  onClick={onClose}
+                >
+                  <span className="flex-1">{item.label}</span>
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="size-4 opacity-30 transition-all group-hover:translate-x-0.5 group-hover:opacity-60"
+                  />
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+
+        {actions.length > 0 ? (
+          <div className="mt-5 border-t border-rule pt-5">
+            <p className="section-eyebrow mb-3">Get started</p>
+            <div className="grid gap-2">
+              {actions.map((action) =>
+                action.type === "link" ? (
+                  <a
+                    key={action.href}
+                    className={`btn justify-center ${
+                      action.variant === "primary" ? "btn-primary" : "btn-ghost"
+                    }`}
+                    href={action.href}
+                    onClick={onClose}
+                  >
+                    {action.label}
+                  </a>
+                ) : null,
+              )}
+            </div>
+          </div>
+        ) : null}
       </div>
-    </div>
+    </div>,
+    document.body,
+  );
+}
+
+export function HeaderMobileAccountPanel({
+  actions,
+  onClose,
+  accountName,
+  accountHandle,
+  avatarInitial,
+  themeMode,
+  onToggleThemeMode,
+}: HeaderMobileAccountPanelProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    document.body.style.overflow = "hidden";
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div className="animate-mobileMenuIn fixed inset-0 z-[60] flex flex-col bg-paper/[0.97] backdrop-blur-xl">
+      <div className="pointer-events-none absolute inset-0 grid-bg opacity-20" />
+
+      {/* top bar */}
+      <header className="relative flex items-center justify-between border-b border-rule px-5 py-3">
+        <Brand />
+        <div className="flex items-center gap-1">
+          <HeaderThemeToggle
+            themeMode={themeMode}
+            onToggleThemeMode={onToggleThemeMode}
+          />
+          <button
+            aria-label="Close menu"
+            className="btn btn-ghost size-10 border-0 p-0"
+            onClick={onClose}
+            type="button"
+          >
+            <X aria-hidden="true" className="size-4" />
+          </button>
+        </div>
+      </header>
+
+      {/* account body */}
+      <div className="relative flex-1 overflow-y-auto px-5 py-5">
+        <p className="section-eyebrow mb-4">Account</p>
+
+        {/* user card */}
+        <div className="mb-5 flex items-center gap-3 rounded-brand bg-paper-2 px-4 py-3">
+          <span className="grid size-9 shrink-0 place-items-center rounded-full bg-ink text-sm font-semibold uppercase text-paper">
+            {avatarInitial}
+          </span>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-ink">
+              {accountName}
+            </div>
+            <div className="truncate text-xs text-ink-4">{accountHandle}</div>
+          </div>
+        </div>
+
+        {/* account links styled like nav items */}
+        <ul className="flex flex-col">
+          {actions.map((action, index) => (
+            <li
+              key={action.type === "link" ? action.href : action.label}
+              className="mobile-menu-item border-b border-rule last:border-b-0"
+              style={{ animationDelay: `${60 + index * 35}ms` }}
+            >
+              {action.type === "link" ? (
+                <a
+                  className="group flex items-center gap-3 py-3 text-[15px] font-medium text-ink-2 transition-colors hover:text-ink"
+                  href={action.href}
+                  onClick={onClose}
+                >
+                  <span className="flex-1">{action.label}</span>
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="size-4 opacity-30 transition-all group-hover:translate-x-0.5 group-hover:opacity-60"
+                  />
+                </a>
+              ) : (
+                <button
+                  className="group flex w-full items-center gap-3 py-3 text-[15px] font-medium text-ink-2 transition-colors hover:text-ink"
+                  disabled={action.disabled}
+                  onClick={() => {
+                    onClose();
+                    void action.onClick();
+                  }}
+                  type="button"
+                >
+                  <span className="flex-1 text-left">{action.label}</span>
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="size-4 opacity-30 transition-all group-hover:translate-x-0.5 group-hover:opacity-60"
+                  />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>,
+    document.body,
   );
 }

--- a/apps/web/src/components/layout/Header/HeaderThemeToggle.tsx
+++ b/apps/web/src/components/layout/Header/HeaderThemeToggle.tsx
@@ -9,7 +9,7 @@ export function HeaderThemeToggle({
   return (
     <button
       aria-label={`Switch to ${themeMode === "dark" ? "light" : "dark"} theme`}
-      className="btn btn-ghost size-10 p-0"
+      className="btn btn-ghost size-10 border-0 p-0"
       onClick={onToggleThemeMode}
       type="button"
     >

--- a/apps/web/src/components/layout/Header/headerTypes.ts
+++ b/apps/web/src/components/layout/Header/headerTypes.ts
@@ -41,4 +41,17 @@ export interface HeaderMobileMenuPanelProps {
   items: HeaderNavItem[];
   actions: HeaderActionItem[];
   onClose: () => void;
+  pathname: string;
+  themeMode: ThemeMode;
+  onToggleThemeMode: () => void;
+}
+
+export interface HeaderMobileAccountPanelProps {
+  actions: HeaderActionItem[];
+  onClose: () => void;
+  accountName: string;
+  accountHandle: string;
+  avatarInitial: string;
+  themeMode: ThemeMode;
+  onToggleThemeMode: () => void;
 }

--- a/apps/web/src/components/ui/Brand.tsx
+++ b/apps/web/src/components/ui/Brand.tsx
@@ -1,10 +1,26 @@
-export function Brand() {
-  return (
-    <div className="brand">
-      <span className="brand-mark">j</span>
+interface BrandProps {
+  href?: string;
+  className?: string;
+}
+
+export function Brand({ href, className }: BrandProps) {
+  const content = (
+    <>
+      <span className="brand-mark">J</span>
       <span>
         jymb<span className="brand-dot">.</span>blog
       </span>
-    </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a className={`brand${className ? ` ${className}` : ""}`} href={href}>
+        {content}
+      </a>
+    );
+  }
+  return (
+    <div className={`brand${className ? ` ${className}` : ""}`}>{content}</div>
   );
 }

--- a/apps/web/src/features/auth/auth.css
+++ b/apps/web/src/features/auth/auth.css
@@ -453,3 +453,7 @@
   .auth-shell { grid-template-columns: 1fr; }
   .auth-side { display: none; }
 }
+
+@media (max-width: 480px) {
+  .oauth-btns-compact { grid-template-columns: 1fr; }
+}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
 @import "./theme.css";
 @import "../features/auth/auth.css";

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -1,7 +1,7 @@
 @theme {
-  --font-sans: "Inter Tight", "Inter", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "Inter Tight", "Inter", ui-monospace, SFMono-Regular, Menlo, monospace;
-  --font-serif: "Inter Tight", "Inter", ui-serif, Georgia, serif;
+  --font-sans: "Poppins", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-serif: "Poppins", ui-serif, Georgia, serif;
 
   --color-paper: var(--paper);
   --color-paper-2: var(--paper-2);
@@ -28,26 +28,32 @@
 :root {
   color-scheme: light;
 
-  --paper: #fafaf7;
-  --paper-2: #f4f3ee;
-  --paper-3: #ecebe4;
-  --rule: #d9d8d0;
-  --rule-2: #e8e7df;
-  --ink: #15161a;
-  --ink-2: #2a2c33;
-  --ink-3: #4a4d56;
-  --ink-4: #6e7280;
-  --ink-5: #9c9ea6;
+  --paper: #f2f4f8;
+  --paper-2: #eaecf3;
+  --paper-3: #dfe2ed;
+  --rule: #d2d6e3;
+  --rule-2: #dce0ea;
+  --ink: #0d1220;
+  --ink-2: #1a2235;
+  --ink-3: #3a4966;
+  --ink-4: #6a7290;
+  --ink-5: #9aa3bc;
 
-  --accent: oklch(0.52 0.16 255);
-  --accent-soft: oklch(0.92 0.04 255);
-  --accent-ink: oklch(0.38 0.14 255);
+  --accent: oklch(0.48 0.13 198);
+  --accent-soft: oklch(0.92 0.04 198);
+  --accent-ink: oklch(0.36 0.11 198);
 
-  --tag-1: oklch(0.52 0.12 255);
-  --tag-2: oklch(0.52 0.12 30);
-  --tag-3: oklch(0.52 0.12 145);
-  --tag-4: oklch(0.52 0.12 305);
-  --tag-5: oklch(0.52 0.12 75);
+  --glow-1: hsla(187, 90%, 50%, 0.05);
+  --glow-2: hsla(260, 70%, 60%, 0.04);
+
+  --accent-2: oklch(0.60 0.18 295);
+  --hint-color: var(--paper);
+
+  --tag-1: oklch(0.52 0.12 198);
+  --tag-2: oklch(0.52 0.12 40);
+  --tag-3: oklch(0.52 0.12 158);
+  --tag-4: oklch(0.52 0.12 295);
+  --tag-5: oklch(0.52 0.12 80);
 
   --grid: 8px;
   --max-w: 1120px;
@@ -57,20 +63,26 @@
 :root[data-mode="dark"] {
   color-scheme: dark;
 
-  --paper: #131418;
-  --paper-2: #1b1d22;
-  --paper-3: #24262d;
-  --rule: #2f3138;
-  --rule-2: #25272e;
-  --ink: #f3f1ea;
-  --ink-2: #d6d4cd;
-  --ink-3: #a8a8a4;
-  --ink-4: #7d7e83;
-  --ink-5: #5a5c63;
+  --paper: #080d1a;
+  --paper-2: #0f1628;
+  --paper-3: #172035;
+  --rule: #202c41;
+  --rule-2: #1a2538;
+  --ink: #f2f4f8;
+  --ink-2: #c4cad8;
+  --ink-3: #9aa3b4;
+  --ink-4: #6c7585;
+  --ink-5: #4a5262;
 
-  --accent: oklch(0.72 0.16 255);
-  --accent-soft: oklch(0.28 0.08 255);
-  --accent-ink: oklch(0.78 0.14 255);
+  --accent: oklch(0.75 0.16 198);
+  --accent-soft: oklch(0.26 0.08 198);
+  --accent-ink: oklch(0.80 0.14 198);
+
+  --accent-2: oklch(0.75 0.18 295);
+  --hint-color: var(--paper);
+
+  --glow-1: hsla(187, 92%, 55%, 0.07);
+  --glow-2: hsla(260, 70%, 65%, 0.05);
 }
 
 @layer base {
@@ -85,6 +97,10 @@
     transition:
       background-color 250ms ease,
       color 250ms ease;
+    background-image:
+      radial-gradient(circle at 20% 0%, var(--glow-1), transparent 40%),
+      radial-gradient(circle at 80% 30%, var(--glow-2), transparent 45%);
+    background-attachment: fixed;
   }
 
   body {
@@ -196,6 +212,7 @@
   }
 
   .nav-links a {
+    position: relative;
     border-radius: 6px;
     padding: 8px 12px;
     transition:
@@ -203,10 +220,61 @@
       color 150ms ease;
   }
 
-  .nav-links a:hover,
-  .nav-links a.active {
+  .nav-links a:hover {
     background: var(--paper-2);
     color: var(--ink);
+  }
+
+  .nav-links a.active {
+    color: var(--accent-ink);
+    background: transparent;
+  }
+
+  .nav-links a.active::after {
+    content: "";
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 50%;
+    height: 2px;
+    background: var(--accent);
+    border-radius: 999px;
+  }
+
+  .nav-link {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--ink-3);
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .nav-link:hover {
+    background: var(--paper-2);
+    color: var(--ink);
+  }
+
+  .nav-link.active {
+    color: var(--accent-ink);
+  }
+
+  .nav-link.active::after {
+    content: "";
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 50%;
+    height: 2px;
+    background: var(--accent);
+    border-radius: 999px;
   }
 
   .nav-cta {
@@ -220,6 +288,16 @@
     border-radius: 8px;
     background: var(--paper);
     padding: 20px;
+    transition:
+      transform 300ms ease,
+      border-color 300ms ease,
+      box-shadow 300ms ease;
+  }
+
+  .card:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in oklab, var(--accent) 40%, transparent);
+    box-shadow: 0 4px 14px -8px color-mix(in oklab, var(--accent) 20%, transparent);
   }
 
   .btn {
@@ -238,6 +316,8 @@
     line-height: 1;
     white-space: nowrap;
     transition:
+      transform 200ms ease,
+      box-shadow 200ms ease,
       background-color 150ms ease,
       border-color 150ms ease,
       color 150ms ease;
@@ -249,36 +329,57 @@
   }
 
   .btn-primary {
-    border-color: var(--ink);
-    background: var(--ink);
-    color: var(--paper);
+    border-color: var(--accent);
+    background: var(--accent);
+    color: var(--hint-color);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 40%, transparent);
+    transition:
+      transform 200ms ease,
+      box-shadow 200ms ease,
+      background-color 150ms ease,
+      border-color 150ms ease;
   }
 
   .btn-primary:hover {
-    border-color: var(--ink-2);
-    background: var(--ink-2);
-    color: var(--paper);
+    transform: translateY(-1px);
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--accent) 70%, transparent),
+      0 8px 28px -4px color-mix(in oklab, var(--accent) 45%, transparent);
   }
 
   .btn-accent {
     border-color: var(--accent);
     background: var(--accent);
-    color: white;
+    color: var(--hint-color);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 40%, transparent);
+    transition:
+      transform 200ms ease,
+      box-shadow 200ms ease,
+      background-color 150ms ease;
   }
 
   .btn-accent:hover {
-    border-color: var(--accent-ink);
-    background: var(--accent-ink);
+    transform: translateY(-1px);
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--accent) 70%, transparent),
+      0 8px 28px -4px color-mix(in oklab, var(--accent) 45%, transparent);
   }
 
   .btn-ghost {
-    border-color: transparent;
+    border-color: var(--rule);
     background: transparent;
+    color: var(--ink);
   }
 
   .btn-ghost:hover {
-    border-color: var(--rule);
-    background: var(--paper-2);
+    transform: translateY(-1px);
+    border-color: color-mix(in oklab, var(--accent) 70%, transparent);
+    background: color-mix(in oklab, var(--accent) 10%, transparent);
+    color: var(--accent-ink);
   }
 
   .btn-sm {
@@ -696,6 +797,7 @@
 
   .field input:focus {
     border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 15%, transparent);
   }
 
   .field select {
@@ -796,4 +898,226 @@
   .mode-toggle .txt {
     display: none;
   }
+}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--paper);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--rule);
+  border-radius: 5px;
+  border: 1px solid transparent;
+  background-clip: content-box;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklab, var(--accent) 60%, transparent);
+  border: 1px solid transparent;
+  background-clip: content-box;
+}
+
+/* ── Typography utilities ── */
+.font-mono-tech {
+  font-family: var(--font-mono);
+  letter-spacing: -0.01em;
+}
+
+.section-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-eyebrow::before {
+  content: "";
+  width: 28px;
+  height: 1px;
+  background: var(--accent);
+  display: inline-block;
+}
+
+.text-accent-gradient {
+  background: linear-gradient(
+    135deg,
+    var(--accent) 0%,
+    var(--accent-2) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.span-text {
+  color: var(--accent-ink);
+  font-family: var(--font-mono);
+}
+
+/* ── Surface utilities ── */
+.glass-card {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  box-shadow: 0 1px 0 color-mix(in oklab, var(--accent) 4%, transparent) inset;
+}
+
+.dot-bg {
+  background-image: radial-gradient(var(--rule) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+.section-alt {
+  background-color: var(--paper-2);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+}
+
+.section-alt::before,
+.section-alt::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  height: 1px;
+  width: min(70%, 600px);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in oklab, var(--accent) 40%, transparent) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+.section-alt::before { top: -1px; }
+.section-alt::after  { bottom: -1px; }
+
+/* ── Status dot ── */
+.status-dot {
+  position: relative;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #22c55e;
+  box-shadow: 0 0 0 4px hsla(142, 71%, 45%, 0.15);
+}
+
+.status-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: #22c55e;
+  animation: pingDot 1.6s ease-out infinite;
+}
+
+@keyframes pingDot {
+  0%       { transform: scale(1);   opacity: 0.7; }
+  80%, 100% { transform: scale(2.4); opacity: 0;   }
+}
+
+/* ── Avatar glow ── */
+.avatar-glow {
+  position: relative;
+}
+
+.avatar-glow::before {
+  content: "";
+  position: absolute;
+  inset: -8px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklab, var(--accent) 50%, transparent),
+    transparent 60%
+  );
+  filter: blur(24px);
+  z-index: -1;
+}
+
+/* ── Scroll-reveal animations ── */
+.hidden-left {
+  opacity: 0;
+  transform: translateX(-24px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.hidden-right {
+  opacity: 0;
+  transform: translateX(24px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.animate-side {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.hidden-up {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.hidden-down {
+  opacity: 0;
+  transform: translateY(-24px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.animate-up {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hidden-pop {
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.animate-pop {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(24px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes miniSlideIn {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.animate-slideIn {
+  animation: miniSlideIn 0.3s ease-out forwards;
+}
+
+@keyframes mobileMenuIn {
+  from { opacity: 0; transform: scale(1.02); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.animate-mobileMenuIn {
+  animation: mobileMenuIn 0.25s ease-out forwards;
+}
+
+@keyframes mobileItemIn {
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.mobile-menu-item {
+  opacity: 0;
+  animation: mobileItemIn 0.4s ease-out forwards;
 }


### PR DESCRIPTION
- Replace color tokens with oklch/HSL palette (blue-gray light, deep navy dark)
- Switch fonts to Poppins + JetBrains Mono
- Add background glow, scrollbar, selection, and utility classes (glass-card, dot-bg, grid-bg, section-eyebrow, font-mono-tech, avatar-glow, etc.)
- Port scroll-reveal animations and mobile menu keyframes from resume
- Unify Brand component with href/className props; replace all inline logos in Header, Footer, mobile menus, and MaintenancePage
- Redesign desktop account dropdown: accent-topped card, icon-per-item (LayoutDashboard, User, LogOut), destructive sign-out style, ArrowRight hover
- Rebuild mobile header as fullscreen overlay portal with staggered nav items
- Add HeaderMobileAccountPanel as separate fullscreen overlay for signed-in mobile users
- Remove border-0 on avatar, theme toggle, and mobile overlay icon buttons
- Stack OAuth buttons single-column on mobile (max-width: 480px)
- QA fixes: dead props removed from HeaderMobileMenuPanel, mobile user card border replaced with bg-paper-2, all panel X buttons border-free