### PR TITLE
Post structure

### DIFF
--- a/apps/api/app/Http/Controllers/Api/V1/Admin/PostController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/Admin/PostController.php
@@ -10,7 +10,6 @@ use App\Models\Post;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 class PostController extends Controller
 {
@@ -27,9 +26,11 @@ class PostController extends Controller
 
     public function store(StorePostRequest $request): JsonResponse
     {
-        $data = $this->postData($request->validated(), $request->user()->id);
+        $data = $this->postData($request->validated());
 
-        $post = Post::query()->create($data);
+        $post = new Post($data);
+        $post->user()->associate($request->user());
+        $post->save();
         $post->tags()->sync($request->validated('tag_ids', []));
 
         return (new PostResource($post->load(['user', 'tags'])->loadCount(['comments', 'stars'])))
@@ -39,7 +40,7 @@ class PostController extends Controller
 
     public function update(UpdatePostRequest $request, Post $post): PostResource
     {
-        $data = $this->postData($request->validated(), $post->user_id);
+        $data = $this->postData($request->validated());
 
         $post->update($data);
 
@@ -57,17 +58,9 @@ class PostController extends Controller
         return response()->json([], 204);
     }
 
-    private function postData(array $validated, ?int $defaultUserId): array
+    private function postData(array $validated): array
     {
         $data = Arr::except($validated, ['tag_ids']);
-
-        if (array_key_exists('title', $data) && empty($data['slug'])) {
-            $data['slug'] = Str::slug($data['title']);
-        }
-
-        if (! array_key_exists('user_id', $data)) {
-            $data['user_id'] = $defaultUserId;
-        }
 
         if (($data['status'] ?? null) === 'published' && empty($data['published_at'])) {
             $data['published_at'] = now();

--- a/apps/api/app/Http/Controllers/Api/V1/Admin/PostController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/Admin/PostController.php
@@ -3,29 +3,76 @@
 namespace App\Http\Controllers\Api\V1\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StorePostRequest;
+use App\Http\Requests\Admin\UpdatePostRequest;
+use App\Http\Resources\PostResource;
+use App\Models\Post;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class PostController extends Controller
 {
-    public function index(): JsonResponse
+    public function index(): AnonymousResourceCollection
     {
-        return response()->json([]);
+        $posts = Post::query()
+            ->with(['user', 'tags'])
+            ->withCount(['comments', 'stars'])
+            ->latest()
+            ->paginate(20);
+
+        return PostResource::collection($posts);
     }
 
-    public function store(): JsonResponse
+    public function store(StorePostRequest $request): JsonResponse
     {
-        return response()->json([], 201);
+        $data = $this->postData($request->validated(), $request->user()->id);
+
+        $post = Post::query()->create($data);
+        $post->tags()->sync($request->validated('tag_ids', []));
+
+        return (new PostResource($post->load(['user', 'tags'])->loadCount(['comments', 'stars'])))
+            ->response()
+            ->setStatusCode(201);
     }
 
-    public function update(string $post): JsonResponse
+    public function update(UpdatePostRequest $request, Post $post): PostResource
     {
-        return response()->json([
-            'id' => $post,
-        ]);
+        $data = $this->postData($request->validated(), $post->user_id);
+
+        $post->update($data);
+
+        if ($request->has('tag_ids')) {
+            $post->tags()->sync($request->validated('tag_ids', []));
+        }
+
+        return new PostResource($post->load(['user', 'tags'])->loadCount(['comments', 'stars']));
     }
 
-    public function destroy(string $post): JsonResponse
+    public function destroy(Post $post): JsonResponse
     {
+        $post->delete();
+
         return response()->json([], 204);
+    }
+
+    private function postData(array $validated, ?int $defaultUserId): array
+    {
+        $data = Arr::except($validated, ['tag_ids']);
+
+        if (array_key_exists('title', $data) && empty($data['slug'])) {
+            $data['slug'] = Str::slug($data['title']);
+        }
+
+        if (! array_key_exists('user_id', $data)) {
+            $data['user_id'] = $defaultUserId;
+        }
+
+        if (($data['status'] ?? null) === 'published' && empty($data['published_at'])) {
+            $data['published_at'] = now();
+        }
+
+        return $data;
     }
 }

--- a/apps/api/app/Http/Controllers/Api/V1/Admin/TagController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/Admin/TagController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\TagResource;
+use App\Models\Tag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+
+class TagController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        return TagResource::collection(Tag::query()->orderBy('name')->get());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:tags,slug'],
+        ]);
+
+        $tag = Tag::query()->create([
+            'name' => $data['name'],
+            'slug' => $data['slug'] ?? Str::slug($data['name']),
+        ]);
+
+        return (new TagResource($tag))->response()->setStatusCode(201);
+    }
+
+    public function update(Request $request, Tag $tag): TagResource
+    {
+        $data = $request->validate([
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255', Rule::unique('tags', 'slug')->ignore($tag->id)],
+        ]);
+
+        if (array_key_exists('name', $data)) {
+            $tag->name = $data['name'];
+        }
+
+        if (array_key_exists('slug', $data)) {
+            $tag->slug = $data['slug'] ?: Str::slug($tag->name);
+        }
+
+        $tag->save();
+
+        return new TagResource($tag);
+    }
+
+    public function destroy(Tag $tag): JsonResponse
+    {
+        $tag->delete();
+
+        return response()->json([], 204);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/V1/Admin/TagController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/Admin/TagController.php
@@ -15,19 +15,25 @@ class TagController extends Controller
 {
     public function index(): AnonymousResourceCollection
     {
-        return TagResource::collection(Tag::query()->orderBy('name')->get());
+        return TagResource::collection(Tag::query()->orderBy('name')->paginate(100));
     }
 
     public function store(Request $request): JsonResponse
     {
+        if ($request->has('name') && ! $request->filled('slug')) {
+            $request->merge([
+                'slug' => Str::slug((string) $request->input('name')),
+            ]);
+        }
+
         $data = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'slug' => ['nullable', 'string', 'max:255', 'unique:tags,slug'],
+            'slug' => ['required', 'string', 'max:255', 'unique:tags,slug'],
         ]);
 
         $tag = Tag::query()->create([
             'name' => $data['name'],
-            'slug' => $data['slug'] ?? Str::slug($data['name']),
+            'slug' => $data['slug'],
         ]);
 
         return (new TagResource($tag))->response()->setStatusCode(201);
@@ -35,9 +41,15 @@ class TagController extends Controller
 
     public function update(Request $request, Tag $tag): TagResource
     {
+        if ($request->has('slug') && ! $request->filled('slug')) {
+            $request->merge([
+                'slug' => Str::slug((string) $request->input('name', $tag->name)),
+            ]);
+        }
+
         $data = $request->validate([
             'name' => ['sometimes', 'required', 'string', 'max:255'],
-            'slug' => ['sometimes', 'nullable', 'string', 'max:255', Rule::unique('tags', 'slug')->ignore($tag->id)],
+            'slug' => ['sometimes', 'required', 'string', 'max:255', Rule::unique('tags', 'slug')->ignore($tag->id)],
         ]);
 
         if (array_key_exists('name', $data)) {
@@ -45,7 +57,7 @@ class TagController extends Controller
         }
 
         if (array_key_exists('slug', $data)) {
-            $tag->slug = $data['slug'] ?: Str::slug($tag->name);
+            $tag->slug = $data['slug'];
         }
 
         $tag->save();

--- a/apps/api/app/Http/Controllers/Api/V1/PostController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/PostController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\PostResource;
+use App\Http\Resources\PostSummaryResource;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class PostController extends Controller
+{
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $posts = Post::query()
+            ->with(['user', 'tags'])
+            ->withCount(['comments', 'stars'])
+            ->where('status', 'published')
+            ->whereNotNull('published_at')
+            ->when($request->filled('tag'), function ($query) use ($request) {
+                $query->whereHas('tags', fn ($tagQuery) => $tagQuery
+                    ->where('slug', $request->string('tag')->toString()));
+            })
+            ->when($request->has('featured'), function ($query) use ($request) {
+                $query->where('is_featured', filter_var($request->query('featured'), FILTER_VALIDATE_BOOLEAN));
+            })
+            ->when($request->filled('search'), function ($query) use ($request) {
+                $search = $request->string('search')->toString();
+
+                $query->where(function ($searchQuery) use ($search) {
+                    $searchQuery
+                        ->where('title', 'like', '%'.$search.'%')
+                        ->orWhere('excerpt', 'like', '%'.$search.'%');
+                });
+            })
+            ->latest('published_at')
+            ->paginate(min(max((int) $request->integer('per_page', 12), 1), 50));
+
+        return PostSummaryResource::collection($posts);
+    }
+
+    public function show(string $slug): PostResource
+    {
+        $post = Post::query()
+            ->with(['user', 'tags'])
+            ->withCount(['comments', 'stars'])
+            ->where('slug', $slug)
+            ->where('status', 'published')
+            ->whereNotNull('published_at')
+            ->firstOrFail();
+
+        return new PostResource($post);
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/V1/PostStarController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/PostStarController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PostStarController extends Controller
+{
+    public function store(Request $request, string $slug): JsonResponse
+    {
+        $post = $this->publishedPost($slug);
+
+        $post->stars()->firstOrCreate([
+            'user_id' => $request->user()->id,
+        ]);
+
+        return response()->json([], 201);
+    }
+
+    public function destroy(Request $request, string $slug): JsonResponse
+    {
+        $post = $this->publishedPost($slug);
+
+        $post->stars()
+            ->where('user_id', $request->user()->id)
+            ->delete();
+
+        return response()->json([], 204);
+    }
+
+    private function publishedPost(string $slug): Post
+    {
+        return Post::query()
+            ->where('slug', $slug)
+            ->where('status', 'published')
+            ->whereNotNull('published_at')
+            ->firstOrFail();
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/V1/TagController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/TagController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\TagResource;
+use App\Models\Tag;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class TagController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        return TagResource::collection(
+            Tag::query()->orderBy('name')->get(),
+        );
+    }
+}

--- a/apps/api/app/Http/Controllers/Api/V1/TagController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/TagController.php
@@ -12,7 +12,7 @@ class TagController extends Controller
     public function index(): AnonymousResourceCollection
     {
         return TagResource::collection(
-            Tag::query()->orderBy('name')->get(),
+            Tag::query()->orderBy('name')->paginate(100),
         );
     }
 }

--- a/apps/api/app/Http/Requests/Admin/StorePostRequest.php
+++ b/apps/api/app/Http/Requests/Admin/StorePostRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 
 class StorePostRequest extends FormRequest
 {
@@ -14,21 +15,30 @@ class StorePostRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id' => ['nullable', 'integer', 'exists:users,id'],
             'title' => ['required', 'string', 'max:255'],
-            'slug' => ['nullable', 'string', 'max:255', 'unique:posts,slug'],
-            'excerpt' => ['nullable', 'string'],
-            'cover_image' => ['nullable', 'string', 'max:2048'],
+            'slug' => ['required', 'string', 'max:255', 'unique:posts,slug'],
+            'excerpt' => ['nullable', 'string', 'max:500'],
+            'cover_image' => ['nullable', 'url:https', 'max:2048'],
             'reading_time' => ['nullable', 'integer', 'min:1', 'max:65535'],
-            'body' => ['required', 'array'],
-            'body.*.type' => ['required', 'string'],
-            'body.*.style' => ['required', 'array'],
-            'body.*.children' => ['required', 'array'],
+            'body' => ['required', 'array', 'max:100'],
+            'body.*.type' => ['required', 'string', 'max:80'],
+            'body.*.style' => ['required', 'array', 'max:50'],
+            'body.*.children' => ['required', 'array', 'max:200'],
+            'body.*.children.*.text' => ['sometimes', 'string', 'max:20000'],
             'status' => ['required', 'string', 'in:draft,published,archived'],
             'is_featured' => ['sometimes', 'boolean'],
             'published_at' => ['nullable', 'date'],
-            'tag_ids' => ['sometimes', 'array'],
-            'tag_ids.*' => ['integer', 'exists:tags,id'],
+            'tag_ids' => ['sometimes', 'array', 'max:20'],
+            'tag_ids.*' => ['integer', 'distinct', 'exists:tags,id'],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('title') && ! $this->filled('slug')) {
+            $this->merge([
+                'slug' => Str::slug((string) $this->input('title')),
+            ]);
+        }
     }
 }

--- a/apps/api/app/Http/Requests/Admin/StorePostRequest.php
+++ b/apps/api/app/Http/Requests/Admin/StorePostRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:posts,slug'],
+            'excerpt' => ['nullable', 'string'],
+            'cover_image' => ['nullable', 'string', 'max:2048'],
+            'reading_time' => ['nullable', 'integer', 'min:1', 'max:65535'],
+            'body' => ['required', 'array'],
+            'body.*.type' => ['required', 'string'],
+            'body.*.style' => ['required', 'array'],
+            'body.*.children' => ['required', 'array'],
+            'status' => ['required', 'string', 'in:draft,published,archived'],
+            'is_featured' => ['sometimes', 'boolean'],
+            'published_at' => ['nullable', 'date'],
+            'tag_ids' => ['sometimes', 'array'],
+            'tag_ids.*' => ['integer', 'exists:tags,id'],
+        ];
+    }
+}

--- a/apps/api/app/Http/Requests/Admin/UpdatePostRequest.php
+++ b/apps/api/app/Http/Requests/Admin/UpdatePostRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class UpdatePostRequest extends FormRequest
@@ -17,21 +18,35 @@ class UpdatePostRequest extends FormRequest
         $postId = $this->route('post')?->id;
 
         return [
-            'user_id' => ['sometimes', 'nullable', 'integer', 'exists:users,id'],
             'title' => ['sometimes', 'required', 'string', 'max:255'],
-            'slug' => ['sometimes', 'nullable', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($postId)],
-            'excerpt' => ['sometimes', 'nullable', 'string'],
-            'cover_image' => ['sometimes', 'nullable', 'string', 'max:2048'],
+            'slug' => ['sometimes', 'required', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($postId)],
+            'excerpt' => ['sometimes', 'nullable', 'string', 'max:500'],
+            'cover_image' => ['sometimes', 'nullable', 'url:https', 'max:2048'],
             'reading_time' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:65535'],
-            'body' => ['sometimes', 'required', 'array'],
-            'body.*.type' => ['required_with:body', 'string'],
-            'body.*.style' => ['required_with:body', 'array'],
-            'body.*.children' => ['required_with:body', 'array'],
+            'body' => ['sometimes', 'required', 'array', 'max:100'],
+            'body.*.type' => ['required_with:body', 'string', 'max:80'],
+            'body.*.style' => ['required_with:body', 'array', 'max:50'],
+            'body.*.children' => ['required_with:body', 'array', 'max:200'],
+            'body.*.children.*.text' => ['sometimes', 'string', 'max:20000'],
             'status' => ['sometimes', 'required', 'string', 'in:draft,published,archived'],
             'is_featured' => ['sometimes', 'boolean'],
             'published_at' => ['sometimes', 'nullable', 'date'],
-            'tag_ids' => ['sometimes', 'array'],
-            'tag_ids.*' => ['integer', 'exists:tags,id'],
+            'tag_ids' => ['sometimes', 'array', 'max:20'],
+            'tag_ids.*' => ['integer', 'distinct', 'exists:tags,id'],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('slug') || $this->filled('slug')) {
+            return;
+        }
+
+        $post = $this->route('post');
+        $title = $this->input('title', $post?->title);
+
+        $this->merge([
+            'slug' => Str::slug((string) $title),
+        ]);
     }
 }

--- a/apps/api/app/Http/Requests/Admin/UpdatePostRequest.php
+++ b/apps/api/app/Http/Requests/Admin/UpdatePostRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $postId = $this->route('post')?->id;
+
+        return [
+            'user_id' => ['sometimes', 'nullable', 'integer', 'exists:users,id'],
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($postId)],
+            'excerpt' => ['sometimes', 'nullable', 'string'],
+            'cover_image' => ['sometimes', 'nullable', 'string', 'max:2048'],
+            'reading_time' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:65535'],
+            'body' => ['sometimes', 'required', 'array'],
+            'body.*.type' => ['required_with:body', 'string'],
+            'body.*.style' => ['required_with:body', 'array'],
+            'body.*.children' => ['required_with:body', 'array'],
+            'status' => ['sometimes', 'required', 'string', 'in:draft,published,archived'],
+            'is_featured' => ['sometimes', 'boolean'],
+            'published_at' => ['sometimes', 'nullable', 'date'],
+            'tag_ids' => ['sometimes', 'array'],
+            'tag_ids.*' => ['integer', 'exists:tags,id'],
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/PostResource.php
+++ b/apps/api/app/Http/Resources/PostResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+
+class PostResource extends PostSummaryResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            ...parent::toArray($request),
+            'body' => $this->body,
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/PostSummaryResource.php
+++ b/apps/api/app/Http/Resources/PostSummaryResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostSummaryResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'cover_image' => $this->cover_image,
+            'reading_time' => $this->reading_time,
+            'is_featured' => $this->is_featured,
+            'status' => $this->status,
+            'published_at' => $this->published_at?->toISOString(),
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+            'author' => [
+                'id' => $this->user?->id,
+                'display_name' => $this->user?->display_name,
+                'handle' => $this->user?->handle,
+                'avatar_url' => $this->user?->avatar_url,
+            ],
+            'tags' => TagResource::collection($this->whenLoaded('tags')),
+            'comments_count' => $this->whenCounted('comments'),
+            'stars_count' => $this->whenCounted('stars'),
+        ];
+    }
+}

--- a/apps/api/app/Http/Resources/TagResource.php
+++ b/apps/api/app/Http/Resources/TagResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TagResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+        ];
+    }
+}

--- a/apps/api/app/Models/Post.php
+++ b/apps/api/app/Models/Post.php
@@ -13,7 +13,6 @@ class Post extends Model
     use HasFactory;
 
     protected $fillable = [
-        'user_id',
         'title',
         'slug',
         'excerpt',

--- a/apps/api/app/Models/Post.php
+++ b/apps/api/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Post extends Model
@@ -15,15 +16,20 @@ class Post extends Model
         'user_id',
         'title',
         'slug',
-        'body',
         'excerpt',
+        'cover_image',
+        'reading_time',
+        'body',
         'status',
+        'is_featured',
         'published_at',
     ];
 
     protected function casts(): array
     {
         return [
+            'body' => 'array',
+            'is_featured' => 'boolean',
             'published_at' => 'datetime',
         ];
     }
@@ -36,5 +42,20 @@ class Post extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class)->withTimestamps();
+    }
+
+    public function stars(): HasMany
+    {
+        return $this->hasMany(PostStar::class);
+    }
+
+    public function starredByUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'post_stars')->withTimestamps();
     }
 }

--- a/apps/api/app/Models/PostStar.php
+++ b/apps/api/app/Models/PostStar.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostStar extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'post_id',
+        'user_id',
+    ];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/apps/api/app/Models/Tag.php
+++ b/apps/api/app/Models/Tag.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+
+    public function posts(): BelongsToMany
+    {
+        return $this->belongsToMany(Post::class)->withTimestamps();
+    }
+}

--- a/apps/api/app/Models/User.php
+++ b/apps/api/app/Models/User.php
@@ -46,6 +46,16 @@ class User extends Authenticatable
         return $this->hasMany(PostView::class);
     }
 
+    public function postStars(): HasMany
+    {
+        return $this->hasMany(PostStar::class);
+    }
+
+    public function starredPosts()
+    {
+        return $this->belongsToMany(Post::class, 'post_stars')->withTimestamps();
+    }
+
     protected function casts(): array
     {
         return [

--- a/apps/api/app/OpenApi/ApiDocumentation.php
+++ b/apps/api/app/OpenApi/ApiDocumentation.php
@@ -59,6 +59,115 @@ class ApiDocumentation
     }
 
     #[OA\Get(
+        path: '/posts',
+        operationId: 'listPublicPosts',
+        summary: 'List published posts.',
+        tags: ['Posts'],
+        parameters: [
+            new OA\Parameter(
+                name: 'tag',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Published post list'),
+            new OA\Response(response: 429, description: 'Too many requests'),
+        ],
+    )]
+    public function publicPosts(): void
+    {
+    }
+
+    #[OA\Get(
+        path: '/posts/{slug}',
+        operationId: 'getPublicPost',
+        summary: 'Return a published post with blog editor JSON body.',
+        tags: ['Posts'],
+        parameters: [
+            new OA\Parameter(
+                name: 'slug',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Published post detail'),
+            new OA\Response(response: 404, description: 'Post not found'),
+            new OA\Response(response: 429, description: 'Too many requests'),
+        ],
+    )]
+    public function publicPost(): void
+    {
+    }
+
+    #[OA\Get(
+        path: '/tags',
+        operationId: 'listPublicTags',
+        summary: 'List tags.',
+        tags: ['Tags'],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated tag list'),
+            new OA\Response(response: 429, description: 'Too many requests'),
+        ],
+    )]
+    public function publicTags(): void
+    {
+    }
+
+    #[OA\Post(
+        path: '/posts/{slug}/stars',
+        operationId: 'starPost',
+        summary: 'Star a published post.',
+        security: [['bearerAuth' => []]],
+        tags: ['Posts'],
+        parameters: [
+            new OA\Parameter(
+                name: 'slug',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 201, description: 'Post starred'),
+            new OA\Response(response: 401, description: 'Unauthenticated'),
+            new OA\Response(response: 404, description: 'Post not found'),
+            new OA\Response(response: 429, description: 'Too many requests'),
+        ],
+    )]
+    public function starPost(): void
+    {
+    }
+
+    #[OA\Delete(
+        path: '/posts/{slug}/stars',
+        operationId: 'unstarPost',
+        summary: 'Remove the current user star from a published post.',
+        security: [['bearerAuth' => []]],
+        tags: ['Posts'],
+        parameters: [
+            new OA\Parameter(
+                name: 'slug',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Post unstarred'),
+            new OA\Response(response: 401, description: 'Unauthenticated'),
+            new OA\Response(response: 404, description: 'Post not found'),
+            new OA\Response(response: 429, description: 'Too many requests'),
+        ],
+    )]
+    public function unstarPost(): void
+    {
+    }
+
+    #[OA\Get(
         path: '/admin/posts',
         operationId: 'listAdminPosts',
         summary: 'List admin posts.',
@@ -74,5 +183,38 @@ class ApiDocumentation
     {
     }
 
+    #[OA\Get(
+        path: '/admin/tags',
+        operationId: 'listAdminTags',
+        summary: 'List admin tags.',
+        security: [['bearerAuth' => []]],
+        tags: ['Admin Tags'],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated tag list'),
+            new OA\Response(response: 401, description: 'Unauthenticated'),
+            new OA\Response(response: 403, description: 'Forbidden'),
+        ],
+    )]
+    public function adminTags(): void
+    {
+    }
+
+    #[OA\Post(
+        path: '/admin/tags',
+        operationId: 'createAdminTag',
+        summary: 'Create a tag.',
+        security: [['bearerAuth' => []]],
+        tags: ['Admin Tags'],
+        responses: [
+            new OA\Response(response: 201, description: 'Tag created'),
+            new OA\Response(response: 401, description: 'Unauthenticated'),
+            new OA\Response(response: 403, description: 'Forbidden'),
+            new OA\Response(response: 422, description: 'Validation error'),
+            new OA\Response(response: 429, description: 'Too many requests'),
+        ],
+    )]
+    public function createAdminTag(): void
+    {
+    }
 
 }

--- a/apps/api/app/Services/Auth/UserPermissionService.php
+++ b/apps/api/app/Services/Auth/UserPermissionService.php
@@ -34,7 +34,7 @@ class UserPermissionService
         return $this->isAdmin($user);
     }
 
-    public function canManageCategories(User $user): bool
+    public function canManageTags(User $user): bool
     {
         return $this->isAdmin($user);
     }
@@ -52,7 +52,7 @@ class UserPermissionService
             'manage_posts' => $this->canManagePosts($user),
             'manage_users' => $this->canManageUsers($user),
             'moderate_comments' => $this->canModerateComments($user),
-            'manage_categories' => $this->canManageCategories($user),
+            'manage_tags' => $this->canManageTags($user),
             'upload_media' => $this->canUploadMedia($user),
         ];
     }

--- a/apps/api/database/factories/PostFactory.php
+++ b/apps/api/database/factories/PostFactory.php
@@ -16,10 +16,63 @@ class PostFactory extends Factory
             'user_id' => User::factory(),
             'title' => $title,
             'slug' => Str::slug($title),
-            'body' => fake()->paragraphs(4, true),
             'excerpt' => fake()->paragraph(),
+            'cover_image' => fake()->optional()->imageUrl(1600, 900),
+            'reading_time' => fake()->numberBetween(3, 18),
+            'body' => $this->minimalBlocks($title),
             'status' => 'published',
+            'is_featured' => false,
             'published_at' => fake()->dateTimeBetween('-1 year', 'now'),
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'draft',
+            'is_featured' => false,
+            'published_at' => null,
+        ]);
+    }
+
+    public function featured(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'published',
+            'is_featured' => true,
+            'published_at' => now(),
+        ]);
+    }
+
+    private function minimalBlocks(string $title): array
+    {
+        return [
+            [
+                'type' => 'heading',
+                'level' => 'h1',
+                'style' => [
+                    'base' => [
+                        'fontSize' => '36px',
+                        'fontWeight' => '700',
+                        'lineHeight' => 1.1,
+                    ],
+                ],
+                'children' => [
+                    ['text' => $title],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'style' => [
+                    'base' => [
+                        'fontSize' => '18px',
+                        'lineHeight' => 1.65,
+                    ],
+                ],
+                'children' => [
+                    ['text' => fake()->paragraph()],
+                ],
+            ],
         ];
     }
 }

--- a/apps/api/database/factories/PostStarFactory.php
+++ b/apps/api/database/factories/PostStarFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\PostStar;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PostStar>
+ */
+class PostStarFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'post_id' => Post::factory(),
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/apps/api/database/factories/TagFactory.php
+++ b/apps/api/database/factories/TagFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Tag>
+ */
+class TagFactory extends Factory
+{
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'name' => Str::headline($name),
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1000, 9999),
+        ];
+    }
+}

--- a/apps/api/database/migrations/2026_05_07_021056_create_posts_table.php
+++ b/apps/api/database/migrations/2026_05_07_021056_create_posts_table.php
@@ -16,9 +16,12 @@ return new class extends Migration
             $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
             $table->string('title');
             $table->string('slug')->unique();
-            $table->longText('body');
             $table->text('excerpt')->nullable();
+            $table->string('cover_image')->nullable();
+            $table->unsignedSmallInteger('reading_time')->nullable();
+            $table->json('body');
             $table->string('status')->default('draft');
+            $table->boolean('is_featured')->default(false);
             $table->timestamp('published_at')->nullable();
             $table->timestamps();
         });

--- a/apps/api/database/migrations/2026_05_07_021057_create_tags_table.php
+++ b/apps/api/database/migrations/2026_05_07_021057_create_tags_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/apps/api/database/migrations/2026_05_07_021058_create_post_tag_table.php
+++ b/apps/api/database/migrations/2026_05_07_021058_create_post_tag_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['post_id', 'tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+    }
+};

--- a/apps/api/database/migrations/2026_05_07_080150_create_post_stars_table.php
+++ b/apps/api/database/migrations/2026_05_07_080150_create_post_stars_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_stars', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['post_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_stars');
+    }
+};

--- a/apps/api/database/seeders/DatabaseSeeder.php
+++ b/apps/api/database/seeders/DatabaseSeeder.php
@@ -2,11 +2,14 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-use App\Models\Post;
 use App\Models\Comment;
+use App\Models\Post;
+use App\Models\PostStar;
+use App\Models\Tag;
+use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
 
 class DatabaseSeeder extends Seeder
 {
@@ -20,14 +23,188 @@ class DatabaseSeeder extends Seeder
         $user = User::where('email', 'test@example.com')->first()
             ?? User::factory()->create([
                 'email' => 'test@example.com',
-                'display_name' => 'Test User',
+                'handle' => '@jymb',
+                'display_name' => 'Jymb',
+                'role' => User::ROLE_ADMIN,
             ]);
 
-        $posts = Post::factory(5)->create();
+        $tags = collect(['AI Agents', 'Infrastructure', 'Engineering', 'Testing', 'Workflow'])
+            ->mapWithKeys(function (string $name) {
+                $tag = Tag::query()->firstOrCreate(
+                    ['slug' => Str::slug($name)],
+                    ['name' => $name],
+                );
+
+                return [$tag->slug => $tag];
+            });
+
+        $featured = Post::query()->updateOrCreate(
+            ['slug' => 'cost-of-context'],
+            [
+                'user_id' => $user->id,
+                'title' => "The cost of context: what it actually takes to build agents that don't lie.",
+                'excerpt' => 'Six months running an agent in production taught me that hallucinations are a downstream symptom, not the bug.',
+                'cover_image' => 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=1600&q=80',
+                'reading_time' => 18,
+                'body' => $this->blogPostBlocks(),
+                'status' => 'published',
+                'is_featured' => true,
+                'published_at' => '2026-04-30 00:00:00',
+            ],
+        );
+        $featured->tags()->sync([
+            $tags['ai-agents']->id,
+            $tags['infrastructure']->id,
+            $tags['engineering']->id,
+        ]);
+
+        $posts = collect([$featured])->merge(
+            collect([
+                ['A field guide to flaky tests, and why your CI is lying to you.', 'testing'],
+                ["I rewrote my note-taking system for the fifth time. Here's what stuck.", 'workflow'],
+                ['Vector databases are a deployment problem, not a math problem.', 'infrastructure'],
+                ['A short defense of boring stacks.', 'engineering'],
+            ])->map(function (array $sample) use ($tags, $user) {
+                [$title, $tagSlug] = $sample;
+
+                $post = Post::factory()->create([
+                    'user_id' => $user->id,
+                    'title' => $title,
+                    'slug' => Str::slug($title),
+                    'status' => 'published',
+                    'published_at' => now()->subDays(fake()->numberBetween(1, 40)),
+                ]);
+                $post->tags()->sync([$tags[$tagSlug]->id]);
+
+                return $post;
+            }),
+        );
+
+        Post::factory()
+            ->count(2)
+            ->draft()
+            ->create(['user_id' => $user->id]);
 
         Comment::factory(4)->create([
             'user_id' => $user->id,
             'post_id' => fn() => $posts->random()->id,
         ]);
+
+        User::factory(5)->create()->each(function (User $starUser) use ($featured) {
+            PostStar::factory()->create([
+                'post_id' => $featured->id,
+                'user_id' => $starUser->id,
+            ]);
+        });
+    }
+
+    private function blogPostBlocks(): array
+    {
+        return [
+            [
+                'type' => 'row',
+                'style' => [
+                    'base' => [
+                        'display' => 'flex',
+                        'flexDirection' => 'column',
+                        'width' => '100%',
+                        'paddingTop' => '48px',
+                        'paddingRight' => '20px',
+                        'paddingBottom' => '40px',
+                        'paddingLeft' => '20px',
+                        'backgroundColor' => '#fafaf7',
+                    ],
+                ],
+                'children' => [
+                    [
+                        'type' => 'column',
+                        'style' => [
+                            'base' => [
+                                'flexGrow' => 100,
+                                'display' => 'flex',
+                                'flexDirection' => 'column',
+                                'maxWidth' => '720px',
+                                'marginLeft' => 'auto',
+                                'marginRight' => 'auto',
+                            ],
+                        ],
+                        'children' => [
+                            [
+                                'type' => 'paragraph',
+                                'style' => [
+                                    'base' => [
+                                        'fontSize' => '11px',
+                                        'fontWeight' => '700',
+                                        'color' => '#6e7280',
+                                        'letterSpacing' => '0.06em',
+                                        'textTransform' => 'uppercase',
+                                        'marginBottom' => '18px',
+                                    ],
+                                ],
+                                'children' => [['text' => 'Long read · 18 min · Issue No. 47']],
+                            ],
+                            [
+                                'type' => 'heading',
+                                'level' => 'h1',
+                                'style' => [
+                                    'base' => [
+                                        'fontSize' => '30px',
+                                        'fontWeight' => '600',
+                                        'color' => '#15161a',
+                                        'lineHeight' => 1.06,
+                                        'letterSpacing' => '-0.03em',
+                                    ],
+                                    'md' => ['fontSize' => '42px'],
+                                    'lg' => ['fontSize' => '52px'],
+                                ],
+                                'children' => [['text' => "The cost of context: what it actually takes to build agents that don't lie."]],
+                            ],
+                            [
+                                'type' => 'paragraph',
+                                'style' => [
+                                    'base' => [
+                                        'fontSize' => '17px',
+                                        'lineHeight' => 1.55,
+                                        'color' => '#4a4d56',
+                                        'fontStyle' => 'italic',
+                                    ],
+                                ],
+                                'children' => [['text' => 'Six months running an agent in production taught me that hallucinations are a downstream symptom, not the bug.']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'image',
+                'url' => 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=1600&q=80',
+                'alt' => 'Abstract network of nodes representing context and data flow in an AI agent system',
+                'style' => [
+                    'base' => [
+                        'width' => '100%',
+                        'maxWidth' => '720px',
+                        'marginLeft' => 'auto',
+                        'marginRight' => 'auto',
+                        'aspectRatio' => '16 / 7',
+                        'minHeight' => '220px',
+                        'objectFit' => 'cover',
+                    ],
+                    'md' => ['minHeight' => '320px'],
+                ],
+                'children' => [['text' => '']],
+            ],
+            [
+                'type' => 'paragraph',
+                'style' => [
+                    'base' => [
+                        'fontSize' => '18px',
+                        'lineHeight' => 1.65,
+                        'color' => '#2a2c33',
+                        'marginBottom' => '20px',
+                    ],
+                ],
+                'children' => [['text' => "For the last six months I've been the primary maintainer of a customer-facing agent. We launched expecting hallucinations to be the problem. They were not."]],
+            ],
+        ];
     }
 }

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -3,15 +3,18 @@
 use App\Http\Controllers\Api\V1\SessionController;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V1\PostController as PublicPostController;
+use App\Http\Controllers\Api\V1\PostStarController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\PublicProfileController;
 use App\Http\Controllers\Api\V1\ProfileCommentController;
 use App\Http\Controllers\Api\V1\ProfileNotificationController;
 use App\Http\Controllers\Api\V1\ProfileReadingHistoryController;
+use App\Http\Controllers\Api\V1\TagController as PublicTagController;
 use App\Http\Controllers\Api\V1\Admin\PostController;
 use App\Http\Controllers\Api\V1\Admin\UserController;
 use App\Http\Controllers\Api\V1\Admin\CommentController;
-use App\Http\Controllers\Api\V1\Admin\CategoryController;
+use App\Http\Controllers\Api\V1\Admin\TagController;
 use App\Http\Controllers\Api\V1\Admin\UploadController;
 
 Route::prefix('v1')->group(function () {
@@ -24,8 +27,9 @@ Route::prefix('v1')->group(function () {
     | middleware appended to the api group. Opt-outs must be explicit.
     */
     Route::withoutMiddleware(Authenticate::using('api'))->group(function () {
-        Route::get('/posts', fn() => response()->json([]))->middleware('throttle:public-api');
-        Route::get('/categories', fn() => response()->json([]))->middleware('throttle:public-api');
+        Route::get('/posts', [PublicPostController::class, 'index'])->middleware('throttle:public-api');
+        Route::get('/posts/{slug}', [PublicPostController::class, 'show'])->middleware('throttle:public-api');
+        Route::get('/tags', [PublicTagController::class, 'index'])->middleware('throttle:public-api');
         Route::get('/profiles/{handle}', [PublicProfileController::class, 'show'])->middleware('throttle:public-api');
         Route::post('/posts/{slug}/view', fn() => response()->json([], 202))->middleware('throttle:post-view');
     });
@@ -45,6 +49,9 @@ Route::prefix('v1')->group(function () {
         Route::patch('/profile', [ProfileController::class, 'update'])->middleware('throttle:profile-mutations');
         Route::delete('/profile', [ProfileController::class, 'destroy'])->middleware('throttle:profile-delete');
 
+        Route::post('/posts/{slug}/stars', [PostStarController::class, 'store'])->middleware('throttle:profile-mutations');
+        Route::delete('/posts/{slug}/stars', [PostStarController::class, 'destroy'])->middleware('throttle:profile-mutations');
+
         /*
         |----------------------------------------------------------------------
         | Admin routes — authenticated + admin permission required
@@ -62,10 +69,10 @@ Route::prefix('v1')->group(function () {
             Route::get('/comments', [CommentController::class, 'index'])->middleware('throttle:admin-read');
             Route::patch('/comments/{comment}', [CommentController::class, 'update'])->middleware('throttle:admin-mutations');
 
-            Route::get('/categories', [CategoryController::class, 'index'])->middleware('throttle:admin-read');
-            Route::post('/categories', [CategoryController::class, 'store'])->middleware('throttle:admin-mutations');
-            Route::patch('/categories/{category}', [CategoryController::class, 'update'])->middleware('throttle:admin-mutations');
-            Route::delete('/categories/{category}', [CategoryController::class, 'destroy'])->middleware('throttle:admin-mutations');
+            Route::get('/tags', [TagController::class, 'index'])->middleware('throttle:admin-read');
+            Route::post('/tags', [TagController::class, 'store'])->middleware('throttle:admin-mutations');
+            Route::patch('/tags/{tag}', [TagController::class, 'update'])->middleware('throttle:admin-mutations');
+            Route::delete('/tags/{tag}', [TagController::class, 'destroy'])->middleware('throttle:admin-mutations');
 
             Route::post('/uploads', [UploadController::class, 'store'])->middleware('throttle:admin-mutations');
         });

--- a/apps/api/tests/Feature/Admin/AdminAuthorizationTest.php
+++ b/apps/api/tests/Feature/Admin/AdminAuthorizationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use App\Models\Post;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -24,21 +25,34 @@ it('allows admins to access admin placeholder routes', function () {
     $admin = User::factory()->create([
         'role' => User::ROLE_ADMIN,
     ]);
+    $post = Post::factory()->create();
 
     $this->actingAs($admin, 'api')
         ->getJson('/api/v1/admin/posts')
         ->assertOk();
 
     $this->actingAs($admin, 'api')
-        ->postJson('/api/v1/admin/posts')
+        ->postJson('/api/v1/admin/posts', [
+            'title' => 'Admin authorization post',
+            'body' => [
+                [
+                    'type' => 'paragraph',
+                    'style' => ['base' => ['fontSize' => '18px']],
+                    'children' => [['text' => 'Admin authorization body']],
+                ],
+            ],
+            'status' => 'draft',
+        ])
         ->assertCreated();
 
     $this->actingAs($admin, 'api')
-        ->patchJson('/api/v1/admin/posts/123')
+        ->patchJson('/api/v1/admin/posts/'.$post->id, [
+            'title' => 'Updated admin authorization post',
+        ])
         ->assertOk()
-        ->assertJsonPath('id', '123');
+        ->assertJsonPath('data.id', $post->id);
 
     $this->actingAs($admin, 'api')
-        ->deleteJson('/api/v1/admin/posts/123')
+        ->deleteJson('/api/v1/admin/posts/'.$post->id)
         ->assertNoContent();
 });

--- a/apps/api/tests/Feature/Admin/AdminRouteMatrixTest.php
+++ b/apps/api/tests/Feature/Admin/AdminRouteMatrixTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Post;
+use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -19,17 +21,17 @@ function adminRoutes(): array
         'GET admin comments' => ['GET', '/api/v1/admin/comments', 200],
         'PATCH admin comments' => ['PATCH', '/api/v1/admin/comments/123', 200],
 
-        'GET admin categories' => ['GET', '/api/v1/admin/categories', 200],
-        'POST admin categories' => ['POST', '/api/v1/admin/categories', 201],
-        'PATCH admin categories' => ['PATCH', '/api/v1/admin/categories/123', 200],
-        'DELETE admin categories' => ['DELETE', '/api/v1/admin/categories/123', 204],
+        'GET admin tags' => ['GET', '/api/v1/admin/tags', 200],
+        'POST admin tags' => ['POST', '/api/v1/admin/tags', 201],
+        'PATCH admin tags' => ['PATCH', '/api/v1/admin/tags/123', 200],
+        'DELETE admin tags' => ['DELETE', '/api/v1/admin/tags/123', 204],
 
         'POST admin uploads' => ['POST', '/api/v1/admin/uploads', 201],
     ];
 }
 
 it('rejects guests from every admin route', function (string $method, string $uri) {
-    $this->json($method, $uri)
+    $this->json($method, resolvedAdminRoute($method, $uri))
         ->assertUnauthorized();
 })->with(adminRoutes());
 
@@ -39,7 +41,7 @@ it('forbids normal users from every admin route', function (string $method, stri
     ]);
 
     $this->actingAs($user, 'api')
-        ->json($method, $uri)
+        ->json($method, resolvedAdminRoute($method, $uri))
         ->assertForbidden();
 })->with(adminRoutes());
 
@@ -53,7 +55,7 @@ it('allows admins through every admin placeholder route', function (
     ]);
 
     $this->actingAs($admin, 'api')
-        ->json($method, $uri)
+        ->json($method, resolvedAdminRoute($method, $uri), adminRoutePayload($method, $uri))
         ->assertStatus($expectedStatus);
 })->with(adminRoutes());
 
@@ -86,3 +88,51 @@ it('returns 429 when the admin mutations rate limit is exceeded', function () {
         ->postJson('/api/v1/admin/posts')
         ->assertTooManyRequests();
 });
+
+function resolvedAdminRoute(string $method, string $uri): string
+{
+    if (str_contains($uri, '/admin/posts/123')) {
+        $post = Post::factory()->create();
+
+        return str_replace('123', (string) $post->id, $uri);
+    }
+
+    if (str_contains($uri, '/admin/tags/123')) {
+        $tag = Tag::factory()->create();
+
+        return str_replace('123', (string) $tag->id, $uri);
+    }
+
+    return $uri;
+}
+
+function adminRoutePayload(string $method, string $uri): array
+{
+    if ($method === 'POST' && $uri === '/api/v1/admin/posts') {
+        return [
+            'title' => 'Admin matrix post',
+            'body' => [
+                [
+                    'type' => 'paragraph',
+                    'style' => ['base' => ['fontSize' => '18px']],
+                    'children' => [['text' => 'Admin matrix body']],
+                ],
+            ],
+            'status' => 'draft',
+        ];
+    }
+
+    if ($method === 'POST' && $uri === '/api/v1/admin/tags') {
+        return [
+            'name' => 'Admin Matrix',
+        ];
+    }
+
+    if ($method === 'PATCH' && str_contains($uri, '/admin/tags/')) {
+        return [
+            'name' => 'Admin Matrix Updated',
+        ];
+    }
+
+    return [];
+}

--- a/apps/api/tests/Feature/Admin/AdminRouteMatrixTest.php
+++ b/apps/api/tests/Feature/Admin/AdminRouteMatrixTest.php
@@ -89,6 +89,109 @@ it('returns 429 when the admin mutations rate limit is exceeded', function () {
         ->assertTooManyRequests();
 });
 
+it('returns validation errors for generated post slug collisions', function () {
+    $admin = User::factory()->create([
+        'role' => User::ROLE_ADMIN,
+    ]);
+
+    Post::factory()->create([
+        'slug' => 'duplicate-title',
+    ]);
+
+    $this->actingAs($admin, 'api')
+        ->postJson('/api/v1/admin/posts', adminPostPayload([
+            'title' => 'Duplicate Title',
+        ]))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['slug']);
+});
+
+it('keeps post slugs stable when updating titles without an explicit slug', function () {
+    $admin = User::factory()->create([
+        'role' => User::ROLE_ADMIN,
+    ]);
+
+    $post = Post::factory()->create([
+        'title' => 'Original Title',
+        'slug' => 'original-title',
+    ]);
+
+    $this->actingAs($admin, 'api')
+        ->patchJson("/api/v1/admin/posts/{$post->id}", [
+            'title' => 'Renamed Title',
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.slug', 'original-title');
+
+    expect($post->refresh()->slug)->toBe('original-title');
+});
+
+it('validates admin post payload shape and safe public media URLs', function () {
+    $admin = User::factory()->create([
+        'role' => User::ROLE_ADMIN,
+    ]);
+
+    $this->actingAs($admin, 'api')
+        ->postJson('/api/v1/admin/posts', adminPostPayload([
+            'cover_image' => 'http://example.com/insecure.jpg',
+            'excerpt' => str_repeat('x', 501),
+            'body' => [
+                [
+                    'type' => 'paragraph',
+                    'style' => ['base' => []],
+                    'children' => [
+                        ['text' => str_repeat('x', 20001)],
+                    ],
+                ],
+            ],
+            'tag_ids' => [999999],
+        ]))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'cover_image',
+            'excerpt',
+            'body.0.children.0.text',
+            'tag_ids.0',
+        ]);
+});
+
+it('assigns new admin posts to the authenticated admin instead of request user_id', function () {
+    $admin = User::factory()->create([
+        'role' => User::ROLE_ADMIN,
+    ]);
+    $otherUser = User::factory()->create();
+
+    $this->actingAs($admin, 'api')
+        ->postJson('/api/v1/admin/posts', adminPostPayload([
+            'user_id' => $otherUser->id,
+            'slug' => 'owned-by-admin',
+        ]))
+        ->assertCreated()
+        ->assertJsonPath('data.user_id', $admin->id);
+
+    $this->assertDatabaseHas('posts', [
+        'slug' => 'owned-by-admin',
+        'user_id' => $admin->id,
+    ]);
+});
+
+it('returns validation errors for generated tag slug collisions', function () {
+    $admin = User::factory()->create([
+        'role' => User::ROLE_ADMIN,
+    ]);
+
+    Tag::factory()->create([
+        'slug' => 'duplicate-tag',
+    ]);
+
+    $this->actingAs($admin, 'api')
+        ->postJson('/api/v1/admin/tags', [
+            'name' => 'Duplicate Tag',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['slug']);
+});
+
 function resolvedAdminRoute(string $method, string $uri): string
 {
     if (str_contains($uri, '/admin/posts/123')) {
@@ -106,20 +209,25 @@ function resolvedAdminRoute(string $method, string $uri): string
     return $uri;
 }
 
+function adminPostPayload(array $overrides = []): array
+{
+    return array_merge([
+        'title' => 'Admin matrix post',
+        'body' => [
+            [
+                'type' => 'paragraph',
+                'style' => ['base' => ['fontSize' => '18px']],
+                'children' => [['text' => 'Admin matrix body']],
+            ],
+        ],
+        'status' => 'draft',
+    ], $overrides);
+}
+
 function adminRoutePayload(string $method, string $uri): array
 {
     if ($method === 'POST' && $uri === '/api/v1/admin/posts') {
-        return [
-            'title' => 'Admin matrix post',
-            'body' => [
-                [
-                    'type' => 'paragraph',
-                    'style' => ['base' => ['fontSize' => '18px']],
-                    'children' => [['text' => 'Admin matrix body']],
-                ],
-            ],
-            'status' => 'draft',
-        ];
+        return adminPostPayload();
     }
 
     if ($method === 'POST' && $uri === '/api/v1/admin/tags') {

--- a/apps/api/tests/Feature/Auth/AuthErrorShapeTest.php
+++ b/apps/api/tests/Feature/Auth/AuthErrorShapeTest.php
@@ -25,7 +25,7 @@ function adminOnlyRoutes(): array
         'POST admin posts'      => ['POST', '/api/v1/admin/posts'],
         'GET admin users'       => ['GET',  '/api/v1/admin/users'],
         'GET admin comments'    => ['GET',  '/api/v1/admin/comments'],
-        'GET admin categories'  => ['GET',  '/api/v1/admin/categories'],
+        'GET admin tags'        => ['GET',  '/api/v1/admin/tags'],
         'POST admin uploads'    => ['POST', '/api/v1/admin/uploads'],
     ];
 }

--- a/apps/api/tests/Feature/Auth/SessionEndpointTest.php
+++ b/apps/api/tests/Feature/Auth/SessionEndpointTest.php
@@ -37,6 +37,7 @@ it('returns admin permissions for admins', function () {
         ->assertJsonPath('data.permissions.admin', true)
         ->assertJsonPath('data.permissions.manage_posts', true)
         ->assertJsonPath('data.permissions.manage_users', true)
+        ->assertJsonPath('data.permissions.manage_tags', true)
         ->assertJsonPath('data.permissions.moderate_comments', true);
 });
 

--- a/apps/api/tests/Feature/PostStarTest.php
+++ b/apps/api/tests/Feature/PostStarTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Models\Post;
+use App\Models\PostStar;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('allows an authenticated user to star and unstar a published post once', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create([
+        'slug' => 'starred-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->actingAs($user, 'api')
+        ->postJson('/api/v1/posts/starred-post/stars')
+        ->assertCreated();
+
+    $this->actingAs($user, 'api')
+        ->postJson('/api/v1/posts/starred-post/stars')
+        ->assertCreated();
+
+    expect(PostStar::query()->where('post_id', $post->id)->where('user_id', $user->id)->count())
+        ->toBe(1);
+
+    $this->actingAs($user, 'api')
+        ->deleteJson('/api/v1/posts/starred-post/stars')
+        ->assertNoContent();
+
+    expect(PostStar::query()->where('post_id', $post->id)->where('user_id', $user->id)->count())
+        ->toBe(0);
+});
+
+it('rejects guests from starring posts', function () {
+    Post::factory()->create([
+        'slug' => 'starred-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->postJson('/api/v1/posts/starred-post/stars')
+        ->assertUnauthorized();
+});

--- a/apps/api/tests/Feature/Public/PostEndpointTest.php
+++ b/apps/api/tests/Feature/Public/PostEndpointTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\Post;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('lists only published posts without block bodies', function () {
+    Post::factory()->create([
+        'title' => 'Published post',
+        'slug' => 'published-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    Post::factory()->draft()->create([
+        'title' => 'Draft post',
+        'slug' => 'draft-post',
+    ]);
+
+    $this->getJson('/api/v1/posts')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.slug', 'published-post')
+        ->assertJsonMissingPath('data.0.body')
+        ->assertJsonMissingPath('data.0.content_html')
+        ->assertJsonMissingPath('data.0.content_css')
+        ->assertJsonMissingPath('data.0.content_js');
+});
+
+it('returns a published post detail with blog editor block body', function () {
+    $post = Post::factory()->create([
+        'slug' => 'cost-of-context',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->getJson('/api/v1/posts/cost-of-context')
+        ->assertOk()
+        ->assertJsonPath('data.id', $post->id)
+        ->assertJsonPath('data.body.0.type', 'heading')
+        ->assertJsonPath('data.body.0.style.base.fontSize', '36px')
+        ->assertJsonMissingPath('data.content_html')
+        ->assertJsonMissingPath('data.content_css')
+        ->assertJsonMissingPath('data.content_js');
+});
+
+it('filters published posts by tag slug', function () {
+    $tag = Tag::factory()->create(['slug' => 'ai-agents']);
+    $matching = Post::factory()->create([
+        'slug' => 'matching-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+    $matching->tags()->attach($tag);
+
+    Post::factory()->create([
+        'slug' => 'other-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->getJson('/api/v1/posts?tag=ai-agents')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.slug', 'matching-post')
+        ->assertJsonPath('data.0.tags.0.slug', 'ai-agents');
+});
+
+it('returns 404 for draft post detail', function () {
+    Post::factory()->draft()->create(['slug' => 'draft-post']);
+
+    $this->getJson('/api/v1/posts/draft-post')
+        ->assertNotFound();
+});

--- a/apps/api/tests/Feature/Public/PublicEndpointTest.php
+++ b/apps/api/tests/Feature/Public/PublicEndpointTest.php
@@ -5,16 +5,16 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-it('returns public posts placeholder', function () {
+it('returns public posts collection', function () {
     $this->getJson('/api/v1/posts')
         ->assertOk()
-        ->assertExactJson([]);
+        ->assertJsonStructure(['data']);
 });
 
-it('returns public categories placeholder', function () {
-    $this->getJson('/api/v1/categories')
+it('returns public tags collection', function () {
+    $this->getJson('/api/v1/tags')
         ->assertOk()
-        ->assertExactJson([]);
+        ->assertJsonStructure(['data']);
 });
 
 it('accepts public post view tracking placeholder', function () {
@@ -43,13 +43,13 @@ it('returns 429 when the public posts rate limit is exceeded', function () {
         ->assertTooManyRequests();
 });
 
-it('returns 429 when the public categories rate limit is exceeded', function () {
+it('returns 429 when the public tags rate limit is exceeded', function () {
     $cacheKey = md5('public-api' . '127.0.0.1');
     for ($i = 0; $i < 60; $i++) {
         \Illuminate\Support\Facades\RateLimiter::hit($cacheKey, 60);
     }
 
-    $this->getJson('/api/v1/categories')
+    $this->getJson('/api/v1/tags')
         ->assertTooManyRequests();
 });
 

--- a/apps/api/tests/Feature/Public/PublicRouteDefaultDenyTest.php
+++ b/apps/api/tests/Feature/Public/PublicRouteDefaultDenyTest.php
@@ -12,7 +12,7 @@ function publicRoutes(): array
 {
     return [
         'GET posts'          => ['GET',  '/api/v1/posts'],
-        'GET categories'     => ['GET',  '/api/v1/categories'],
+        'GET tags'           => ['GET',  '/api/v1/tags'],
         'GET public profile' => ['GET',  '/api/v1/profiles/@nobody'],
         'POST post view'     => ['POST', '/api/v1/posts/some-slug/view'],
     ];
@@ -30,6 +30,6 @@ it('does not return 401 on public routes even when a malformed token is sent', f
     expect($response->status())->not->toBe(401);
 })->with([
     'GET posts'      => ['GET',  '/api/v1/posts'],
-    'GET categories' => ['GET',  '/api/v1/categories'],
+    'GET tags'       => ['GET',  '/api/v1/tags'],
     'POST post view' => ['POST', '/api/v1/posts/any-slug/view'],
 ]);

--- a/apps/api/tests/Feature/Routes/ApiRouteCoverageTest.php
+++ b/apps/api/tests/Feature/Routes/ApiRouteCoverageTest.php
@@ -5,7 +5,8 @@ use Illuminate\Support\Facades\Route;
 it('keeps api v1 route test coverage explicit', function () {
     $documentedRoutes = [
         'GET api/v1/posts',
-        'GET api/v1/categories',
+        'GET api/v1/posts/{slug}',
+        'GET api/v1/tags',
         'POST api/v1/posts/{slug}/view',
         'GET api/v1/profiles/{handle}',
 
@@ -16,6 +17,9 @@ it('keeps api v1 route test coverage explicit', function () {
         'GET api/v1/profile',
         'PATCH api/v1/profile',
         'DELETE api/v1/profile',
+
+        'POST api/v1/posts/{slug}/stars',
+        'DELETE api/v1/posts/{slug}/stars',
 
         'GET api/v1/admin/posts',
         'POST api/v1/admin/posts',
@@ -28,10 +32,10 @@ it('keeps api v1 route test coverage explicit', function () {
         'GET api/v1/admin/comments',
         'PATCH api/v1/admin/comments/{comment}',
 
-        'GET api/v1/admin/categories',
-        'POST api/v1/admin/categories',
-        'PATCH api/v1/admin/categories/{category}',
-        'DELETE api/v1/admin/categories/{category}',
+        'GET api/v1/admin/tags',
+        'POST api/v1/admin/tags',
+        'PATCH api/v1/admin/tags/{tag}',
+        'DELETE api/v1/admin/tags/{tag}',
 
         'POST api/v1/admin/uploads',
     ];

--- a/apps/web/src/features/auth/authTypes.ts
+++ b/apps/web/src/features/auth/authTypes.ts
@@ -59,7 +59,9 @@ export type UserPermissions = {
   comment: boolean;
   manage_posts?: boolean;
   manage_users?: boolean;
+  manage_tags?: boolean;
   moderate_comments?: boolean;
+  upload_media?: boolean;
   [key: string]: boolean | undefined;
 };
 

--- a/docs/architecture/api-contract.md
+++ b/docs/architecture/api-contract.md
@@ -42,18 +42,20 @@ Default fields:
 - `id`
 - `title`
 - `slug`
-- `summary`
-- `thumbnail_url`
+- `excerpt`
+- `cover_image`
 - `is_featured`
 - `published_at`
-- `category`
+- `tags`
+- `comments_count`
+- `stars_count`
 - `author`
 
 Suggested query parameters:
 
 - `page`
 - `per_page`
-- `category`
+- `tag`
 - `featured`
 - `search`
 
@@ -66,16 +68,30 @@ Purpose:
 Payload includes:
 
 - list fields
-- `content_html`
-- `content_css`
-- `content_js`
-- analytics summary if exposed publicly later
+- `body` as a blogEditor `BlockElement[]` JSON array
 
-### `GET /api/v1/categories`
+Rendering note:
+
+- Laravel stores and returns editor block JSON only.
+- The web app renders post detail content through the blogEditor public renderer.
+
+### `GET /api/v1/tags`
 
 Purpose:
 
-- list available blog categories
+- list available blog tags
+
+### `POST /api/v1/posts/{slug}/stars`
+
+Purpose:
+
+- star a post as the authenticated user
+
+### `DELETE /api/v1/posts/{slug}/stars`
+
+Purpose:
+
+- remove the authenticated user's star from a post
 
 ### `GET /api/v1/profiles/{handle}`
 
@@ -129,10 +145,10 @@ Admin endpoints are currently scaffolded as protected controller placeholders. T
 
 Future admin business logic belongs behind these routes and should be implemented feature by feature:
 
-- posts: draft, create, edit, publish, unpublish, archive, delete, slug/SEO/category/tag/media fields
+- posts: draft, create, edit, publish, unpublish, archive, delete, slug/SEO/tag/media fields
 - users: list, view, role changes, suspend/restore, activity review
 - comments: list, approve, hide, mark spam, delete, review reports
-- categories: create, rename, reorder, merge, delete
+- tags: create, rename, reorder, merge, delete
 - uploads: create media upload records or broker storage uploads
 - stats: dashboard totals, post views, popular posts, traffic summaries, user/comment growth
 
@@ -174,21 +190,21 @@ Keep controllers as thin request/response classes. Put admin business rules in s
 
 - update comment moderation fields such as status, hidden state, or spam state
 
-### `GET /api/v1/admin/categories`
+### `GET /api/v1/admin/tags`
 
-- dashboard category listing
+- dashboard tag listing
 
-### `POST /api/v1/admin/categories`
+### `POST /api/v1/admin/tags`
 
-- create a category
+- create a tag
 
-### `PATCH /api/v1/admin/categories/{id}`
+### `PATCH /api/v1/admin/tags/{id}`
 
-- update a category
+- update a tag
 
-### `DELETE /api/v1/admin/categories/{id}`
+### `DELETE /api/v1/admin/tags/{id}`
 
-- delete or archive a category
+- delete or archive a tag
 
 ## Analytics Endpoint
 

--- a/docs/architecture/auth-authorization.md
+++ b/docs/architecture/auth-authorization.md
@@ -92,7 +92,7 @@ apps/web
     ├── /dashboard/posts/:id/edit
     ├── /dashboard/users
     ├── /dashboard/comments
-    └── /dashboard/categories
+    └── /dashboard/tags
 ```
 
 `/profile` is the signed-in user's private profile/settings page. It can include fields from `design/profile.html`, such as email, password update, notification settings, comment history, reading history, and account deletion.
@@ -122,7 +122,7 @@ Admin
 ├── Create/edit/delete posts
 ├── Manage users
 ├── Moderate comments
-└── Manage categories
+└── Manage tags
 ```
 
 ## Backend Authorization Scaffold
@@ -145,14 +145,14 @@ GET /api/v1/admin/users
 PATCH /api/v1/admin/users/{user}
 GET /api/v1/admin/comments
 PATCH /api/v1/admin/comments/{comment}
-GET /api/v1/admin/categories
-POST /api/v1/admin/categories
-PATCH /api/v1/admin/categories/{category}
-DELETE /api/v1/admin/categories/{category}
+GET /api/v1/admin/tags
+POST /api/v1/admin/tags
+PATCH /api/v1/admin/tags/{tag}
+DELETE /api/v1/admin/tags/{tag}
 POST /api/v1/admin/uploads
 ```
 
-Admin controller placeholders prove the route and middleware boundary. Real admin business logic comes later by feature area: post publishing, user moderation, comment moderation, category management, media uploads, and website stats.
+Admin controller placeholders prove the route and middleware boundary. Real admin business logic comes later by feature area: post publishing, user moderation, comment moderation, tag management, media uploads, and website stats.
 
 Controllers should use resource-style method names: `index`, `store`, `show`, `update`, and `destroy`. Avoid action-specific method names such as `moderate`; represent moderation as a resource update unless the action truly needs a separate endpoint.
 
@@ -283,15 +283,18 @@ The frontend should rely on these backend capabilities:
 ```text
 Public
 ├── GET /api/v1/posts
+├── GET /api/v1/posts/{slug}
 ├── GET /api/v1/profiles/{handle}
-├── GET /api/v1/categories
+├── GET /api/v1/tags
 └── POST /api/v1/posts/{slug}/view
 
 Authenticated user
 ├── GET /api/v1/session
 ├── GET /api/v1/profile
 ├── PATCH /api/v1/profile
-└── DELETE /api/v1/profile
+├── DELETE /api/v1/profile
+├── POST /api/v1/posts/{slug}/stars
+└── DELETE /api/v1/posts/{slug}/stars
 
 Admin
 ├── GET /api/v1/admin/posts
@@ -302,7 +305,7 @@ Admin
 ├── PATCH /api/v1/admin/comments/{id}
 ├── GET /api/v1/admin/users
 ├── PATCH /api/v1/admin/users/{id}
-├── CRUD /api/v1/admin/categories
+├── CRUD /api/v1/admin/tags
 └── POST /api/v1/admin/uploads
 ```
 
@@ -375,4 +378,4 @@ flowchart TD
 - Guest users are redirected to `/signin` when trying to comment.
 - Normal users can add comments.
 - Comment edit/delete buttons are visible only to the comment owner or an admin.
-- Admin users can create/edit/delete posts, manage users, moderate comments, manage categories, upload media, and review dashboard stats once those business features are implemented.
+- Admin users can create/edit/delete posts, manage users, moderate comments, manage tags, upload media, and review dashboard stats once those business features are implemented.

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -20,12 +20,11 @@ Notes:
 - Supabase Auth is the identity source.
 - Local user records store app-specific metadata and authorization fields.
 
-### categories
+### tags
 
 - `id`
 - `name`
 - `slug`
-- `description` nullable
 - `created_at`
 - `updated_at`
 
@@ -33,15 +32,12 @@ Notes:
 
 - `id`
 - `user_id`
-- `category_id`
 - `title`
 - `slug`
 - `status`
-- `summary` nullable
-- `content_html` nullable
-- `content_css` nullable
-- `content_js` nullable
-- `thumbnail_path` nullable
+- `excerpt` nullable
+- `body` JSON block array from the blogEditor `BlockElement[]` contract
+- `cover_image` nullable
 - `is_featured`
 - `published_at` nullable
 - `created_at`
@@ -53,44 +49,47 @@ Status defaults:
 - `published`
 - `archived` only if later needed
 
-### post_analytics
+### post_tag
+
+- `post_id`
+- `tag_id`
+- `created_at`
+- `updated_at`
+
+### post_stars
 
 - `id`
 - `post_id`
-- `views_count`
-- `likes_count`
-- `dislikes_count`
-- `avg_read_time_seconds` nullable
-- `last_viewed_at` nullable
+- `user_id`
 - `created_at`
 - `updated_at`
 
 ### media assets
 
-Use a separate table only if the app needs searchable upload records, ownership, or moderation state. Otherwise store only `thumbnail_path` and similar references directly on content entities.
+Use a separate table only if the app needs searchable upload records, ownership, or moderation state. Otherwise store public cover image references directly on posts as `cover_image`.
 
 ## Relationships
 
 - one user has many posts
-- one category has many posts
-- one post has one analytics record
+- one post has many comments through `comments.post_id`
+- one post has many tags through `post_tag`
+- one tag has many posts through `post_tag`
+- one post has many stars through `post_stars`
+- one user can star many posts through `post_stars`
 
 ## Legacy Mapping
 
 - `Account` -> `users`
-- `Category` -> `categories`
 - `Blog` -> `posts`
-- `BlogAnalytics` -> `post_analytics`
-- `htmlContent` -> `content_html`
-- `htmlStyle` -> `content_css`
-- `htmlScript` -> `content_js`
-- `htmlThumbnail` -> `thumbnail_path`
+- legacy category/tag concepts -> `tags`
+- legacy HTML content fields -> blogEditor block JSON in `posts.body`
+- `htmlThumbnail` -> `cover_image`
 
 ## Constraints
 
 - `users.supabase_user_id` must be unique
 - `users.email` must be unique
-- `categories.slug` must be unique
+- `tags.slug` must be unique
 - `posts.slug` must be unique
-- `posts.user_id` and `posts.category_id` are required
-
+- `post_tag` must be unique by `post_id` and `tag_id`
+- `post_stars` must be unique by `post_id` and `user_id`

--- a/docs/qa/features/auth-signup.md
+++ b/docs/qa/features/auth-signup.md
@@ -41,7 +41,6 @@ Apply the master checklist at `docs/setup/qa-checklist.md`. Sections relevant to
 - **WARN — Handle collision is silent.** Server silently renames a taken handle (e.g. `@alice` → `@alice2`) with no user notification. User discovers mismatch on their profile. Fix requires a public `GET /api/v1/handle-availability?handle=@alice` endpoint + debounced blur check on the form. Deferred; not a security issue.
 - **WARN — No user provisioning tests.** `AppServiceProvider` provisioning logic (new user creation, handle de-duplication, race-condition catch, email-collision fallback) has no feature test coverage. Deferred as `tests/Feature/Auth/UserProvisioningTest.php`.
 - **WARN — `display_name` from JWT not server-side length-capped.** `normalizeHandleBase` limits handle to 19 chars, but `display_name` from Supabase `user_metadata` is stored as-is. Unlikely in practice (Supabase enforces limits), but worth adding a `substr(…, 0, 120)` guard.
-- **WARN — `manage_categories` / `upload_media` permissions emitted by API but not declared in `UserPermissions` TypeScript type.** Falls through the index signature safely, but should be explicitly typed or removed.
 - **WARN — Security headers** not set at Laravel layer. See login baseline.
 
 ## Key Files

--- a/docs/roadmap/02-phase-2-laravel-api.md
+++ b/docs/roadmap/02-phase-2-laravel-api.md
@@ -30,7 +30,7 @@ Initialize `apps/api` as a Laravel application that serves as the system of busi
 
 - `GET /api/v1/posts`
 - `GET /api/v1/posts/{slug}`
-- `GET /api/v1/categories`
+- `GET /api/v1/tags`
 - `GET /api/v1/session`
 - `GET /api/v1/profile`
 - `PATCH /api/v1/profile`
@@ -43,10 +43,10 @@ Initialize `apps/api` as a Laravel application that serves as the system of busi
 - `PATCH /api/v1/admin/users/{id}`
 - `GET /api/v1/admin/comments`
 - `PATCH /api/v1/admin/comments/{id}`
-- `GET /api/v1/admin/categories`
-- `POST /api/v1/admin/categories`
-- `PATCH /api/v1/admin/categories/{id}`
-- `DELETE /api/v1/admin/categories/{id}`
+- `GET /api/v1/admin/tags`
+- `POST /api/v1/admin/tags`
+- `PATCH /api/v1/admin/tags/{id}`
+- `DELETE /api/v1/admin/tags/{id}`
 - `POST /api/v1/admin/uploads`
 - `POST /api/v1/posts/{slug}/view`
 

--- a/docs/setup/backend-authorization-testing.md
+++ b/docs/setup/backend-authorization-testing.md
@@ -30,10 +30,10 @@ GET    /api/v1/admin/users
 PATCH  /api/v1/admin/users/{user}
 GET    /api/v1/admin/comments
 PATCH  /api/v1/admin/comments/{comment}
-GET    /api/v1/admin/categories
-POST   /api/v1/admin/categories
-PATCH  /api/v1/admin/categories/{category}
-DELETE /api/v1/admin/categories/{category}
+GET    /api/v1/admin/tags
+POST   /api/v1/admin/tags
+PATCH  /api/v1/admin/tags/{tag}
+DELETE /api/v1/admin/tags/{tag}
 POST   /api/v1/admin/uploads
 ```
 


### PR DESCRIPTION
## Summary

- Add the Laravel post model structure for blogEditor JSON content, including tags, post-tag pivoting, and post stars
- Add public post/tag APIs, post detail payloads with `body` block JSON, authenticated star/unstar endpoints, and admin post/tag CRUD
- Harden post/tag validation for slug collisions, HTTPS cover images, body size limits, tag IDs, and admin post ownership
- Add seed/sample post data shaped for the new editor body contract
- Update architecture/API/auth docs for the new post and tag contract

## Backend

- `posts.body` now stores the blogEditor block array JSON
- `tags`, `post_tag`, and `post_stars` added
- Public routes:
  - `GET /api/v1/posts`
  - `GET /api/v1/posts/{slug}`
  - `GET /api/v1/tags`
  - `POST /api/v1/posts/{slug}/stars`
  - `DELETE /api/v1/posts/{slug}/stars`
- Admin routes:
  - `GET /api/v1/admin/posts`
  - `POST /api/v1/admin/posts`
  - `PATCH /api/v1/admin/posts/{post}`
  - `DELETE /api/v1/admin/posts/{post}`
  - `GET /api/v1/admin/tags`
  - `POST /api/v1/admin/tags`
  - `PATCH /api/v1/admin/tags/{tag}`
  - `DELETE /api/v1/admin/tags/{tag}`

## Validation / Security

- Generated post/tag slug collisions return validation errors instead of DB exceptions
- Updating a post title no longer silently changes the public slug
- Admin post creation assigns the authenticated admin as author instead of trusting request `user_id`
- `Post::$fillable` excludes `user_id`
- `cover_image` requires HTTPS URL validation
- Editor `body`, nested child text, excerpt, and tag arrays have size limits
- Public/admin tag lists are paginated

## Tests

- Added public post endpoint coverage
- Added post star coverage
- Expanded admin route matrix coverage for posts/tags
- Added regression tests for slug collisions, stable slugs, invalid post payloads, and request-owned `user_id`

## Verification

- `php artisan test` passed: `143 passed`, `303 assertions`
- `php artisan route:list --path=api/v1` showed `27` routes
- Backend QA found no blocking bugs after hardening

## Notes

- `POST /api/v1/posts/{slug}/view` is still a placeholder and should be wired to real view tracking later.
- Current uncommitted web/editor package changes are not part of this backend PR unless intentionally staged separately.
