### PR TITLE
add - init editor page with block editor

### DIFF
--- a/apps/web/.npmrc
+++ b/apps/web/.npmrc
@@ -1,0 +1,2 @@
+@jymarkb:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${BLOG_EDITOR_TOKEN}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@jymarkb/block-editor": "^1.0.7",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.1",
         "@tailwindcss/vite": "^4.2.4",
@@ -789,6 +790,26 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@jymarkb/block-editor": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@jymarkb/block-editor/1.0.7/4756887f592ad18bdbd3261831b67b84d770ef9e",
+      "integrity": "sha512-eRL+jPJ3i05QDspzJA9yxuBDvBJhUX14sonwQLrCjXRdiiFYmQGo+y/K21CDZ48G89nUROkwLbXSXj3gzLXiJQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "slate": "^0.110.0 || ^0.124.0",
+        "slate-history": "^0.110.0 || ^0.113.0",
+        "slate-react": "^0.110.0 || ^0.124.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2007,6 +2028,13 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/convert-route": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/convert-route/-/convert-route-1.1.1.tgz",
@@ -2090,6 +2118,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dot-case": {
@@ -2286,6 +2328,23 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/isbot-fast": {
       "version": "1.2.0",
@@ -2611,6 +2670,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -2893,6 +2959,16 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2917,6 +2993,66 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/slate": {
+      "version": "0.124.1",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.124.1.tgz",
+      "integrity": "sha512-ii7DwezgvbLAyKtHBIunjTR1kzbNfYLCUKLMzJELlbTZkvHzX4DzN7HKIwcakf6dPxO6AoeT/P7kHOcyTym/hA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/slate-dom": {
+      "version": "0.124.1",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.124.1.tgz",
+      "integrity": "sha512-D3yVibjLZM4Oj4MmXxOEXbjrlf4wJez3OvGABBNYrAP7gXb0d96tKNtWZ0hGm/5y84idw/LHjZ7W1uTYqFR9rQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "slate": ">=0.121.0"
+      }
+    },
+    "node_modules/slate-history": {
+      "version": "0.113.1",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.113.1.tgz",
+      "integrity": "sha512-J9NSJ+UG2GxoW0lw5mloaKcN0JI0x2IA5M5FxyGiInpn+QEutxT1WK7S/JneZCMFJBoHs1uu7S7e6pxQjubHmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.124.0.tgz",
+      "integrity": "sha512-NLN6ME64ChOgJtiVTKwISS1sI/Y8/qN1cwmDTZM9AQJCl+jR3XNCvDsKNrW0kJU+1G3NgIGaYoVWhgIVEIL+Aw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.121.0",
+        "slate-dom": ">=0.119.1"
       }
     },
     "node_modules/snake-case": {
@@ -2995,6 +3131,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.4",
     "vike": "^0.4.258",
-    "vike-react": "^0.6.21"
+    "vike-react": "^0.6.21",
+    "@jymarkb/block-editor": "^1.0.7"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/apps/web/pages/editor/+Page.tsx
+++ b/apps/web/pages/editor/+Page.tsx
@@ -1,0 +1,17 @@
+import { BlockEditor } from '@jymarkb/block-editor';
+
+export default function Pages() {
+    const onChange = (value: any[]) => {
+        console.log("Document changed:", value);
+    }
+
+    const onUpload = async (file: File) => {
+        console.log("Uploading file:", file);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        return URL.createObjectURL(file);
+    }
+
+    return (
+        <BlockEditor onChange={onChange} onUpload={onUpload} initialValue={[]}/>
+    )
+}


### PR DESCRIPTION
## Summary
- Adds `@jymarkb/block-editor` dependency with GitHub Packages registry config via `.npmrc`
- Scaffolds `/editor` route with `BlockEditor` component wired to `onChange` and `onUpload` stubs

## Test plan
- [ ] Set `BLOG_EDITOR_TOKEN` env var to a valid GitHub PAT with `read:packages` scope
- [ ] Run `npm install` in `apps/web/` and confirm `@jymarkb/block-editor` resolves
- [ ] Navigate to `/editor` and confirm the block editor renders without errors
- [ ] Verify `onChange` fires on content edits (check browser console)
- [ ] Verify `onUpload` fires on image/file upload (check browser console)
