### PR TITLE
Landing page backend

### DIFF
--- a/apps/api/app/Http/Controllers/Api/V1/PostController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/PostController.php
@@ -5,51 +5,27 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\PostResource;
 use App\Http\Resources\PostSummaryResource;
-use App\Models\Post;
+use App\Services\Post\PostService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class PostController extends Controller
 {
+    public function __construct(private PostService $postService)
+    {
+    }
+
     public function index(Request $request): AnonymousResourceCollection
     {
-        $posts = Post::query()
-            ->with(['user', 'tags'])
-            ->withCount(['comments', 'stars'])
-            ->where('status', 'published')
-            ->whereNotNull('published_at')
-            ->when($request->filled('tag'), function ($query) use ($request) {
-                $query->whereHas('tags', fn ($tagQuery) => $tagQuery
-                    ->where('slug', $request->string('tag')->toString()));
-            })
-            ->when($request->has('featured'), function ($query) use ($request) {
-                $query->where('is_featured', filter_var($request->query('featured'), FILTER_VALIDATE_BOOLEAN));
-            })
-            ->when($request->filled('search'), function ($query) use ($request) {
-                $search = $request->string('search')->toString();
-
-                $query->where(function ($searchQuery) use ($search) {
-                    $searchQuery
-                        ->where('title', 'like', '%'.$search.'%')
-                        ->orWhere('excerpt', 'like', '%'.$search.'%');
-                });
-            })
-            ->latest('published_at')
-            ->paginate(min(max((int) $request->integer('per_page', 12), 1), 50));
-
-        return PostSummaryResource::collection($posts);
+        return PostSummaryResource::collection(
+            $this->postService->listPublished($request)
+        );
     }
 
     public function show(string $slug): PostResource
     {
-        $post = Post::query()
-            ->with(['user', 'tags'])
-            ->withCount(['comments', 'stars'])
-            ->where('slug', $slug)
-            ->where('status', 'published')
-            ->whereNotNull('published_at')
-            ->firstOrFail();
-
-        return new PostResource($post);
+        return new PostResource(
+            $this->postService->findPublishedBySlug($slug)
+        );
     }
 }

--- a/apps/api/app/Http/Controllers/Api/V1/TagController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/TagController.php
@@ -4,15 +4,19 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\TagResource;
-use App\Models\Tag;
+use App\Services\Tag\TagService;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class TagController extends Controller
 {
+    public function __construct(private TagService $tagService)
+    {
+    }
+
     public function index(): AnonymousResourceCollection
     {
         return TagResource::collection(
-            Tag::query()->orderBy('name')->paginate(100),
+            $this->tagService->listAll(),
         );
     }
 }

--- a/apps/api/app/Services/Post/PostService.php
+++ b/apps/api/app/Services/Post/PostService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services\Post;
+
+use App\Models\Post;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Request;
+
+class PostService
+{
+    public function listPublished(Request $request): LengthAwarePaginator
+    {
+        return Post::query()
+            ->with(['user', 'tags'])
+            ->withCount(['comments', 'stars'])
+            ->where('status', 'published')
+            ->whereNotNull('published_at')
+            ->when($request->filled('tag'), function ($query) use ($request) {
+                $query->whereHas('tags', fn($tagQuery) => $tagQuery
+                    ->where('slug', $request->string('tag')->toString()));
+            })
+            ->when($request->has('featured'), function ($query) use ($request) {
+                $query->where('is_featured', filter_var($request->query('featured'), FILTER_VALIDATE_BOOLEAN));
+            })
+            ->when($request->filled('search'), function ($query) use ($request) {
+                $search = $request->string('search')->toString();
+
+                $query->where(function ($searchQuery) use ($search) {
+                    $searchQuery
+                        ->where('title', 'like', '%' . $search . '%')
+                        ->orWhere('excerpt', 'like', '%' . $search . '%');
+                });
+            })
+            ->latest('published_at')
+            ->paginate(min(max((int) $request->integer('per_page', 12), 1), 50));
+    }
+
+    public function findPublishedBySlug(string $slug): Post
+    {
+        return Post::query()
+            ->with(['user', 'tags'])
+            ->withCount(['comments', 'stars'])
+            ->where('slug', $slug)
+            ->where('status', 'published')
+            ->whereNotNull('published_at')
+            ->firstOrFail();
+    }
+}

--- a/apps/api/app/Services/Tag/TagService.php
+++ b/apps/api/app/Services/Tag/TagService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services\Tag;
+
+use App\Models\Tag;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class TagService
+{
+    public function listAll(): LengthAwarePaginator
+    {
+        return Tag::query()
+            ->orderBy('name')
+            ->paginate(100);
+    }
+}

--- a/apps/api/database/seeders/DatabaseSeeder.php
+++ b/apps/api/database/seeders/DatabaseSeeder.php
@@ -20,12 +20,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $user = User::where('email', 'test@example.com')->first()
+        $user = User::where('email', 'dev.jymarkb@gmail.com')->first()
             ?? User::factory()->create([
-                'email' => 'test@example.com',
-                'handle' => '@jymb',
-                'display_name' => 'Jymb',
-                'role' => User::ROLE_ADMIN,
+                'email' => 'dev.jymarkb@gmail.com',
+                'handle' => '@jymarkb',
+                'display_name' => 'Jymark',
+                'role' => User::ROLE_USER,
             ]);
 
         $tags = collect(['AI Agents', 'Infrastructure', 'Engineering', 'Testing', 'Workflow'])
@@ -64,6 +64,7 @@ class DatabaseSeeder extends Seeder
                 ["I rewrote my note-taking system for the fifth time. Here's what stuck.", 'workflow'],
                 ['Vector databases are a deployment problem, not a math problem.', 'infrastructure'],
                 ['A short defense of boring stacks.', 'engineering'],
+                ['The only diagram I ever draw before writing code.', 'engineering'],
             ])->map(function (array $sample) use ($tags, $user) {
                 [$title, $tagSlug] = $sample;
 

--- a/apps/api/tests/Feature/Public/PostEndpointTest.php
+++ b/apps/api/tests/Feature/Public/PostEndpointTest.php
@@ -68,9 +68,28 @@ it('filters published posts by tag slug', function () {
         ->assertJsonPath('data.0.tags.0.slug', 'ai-agents');
 });
 
+it('filters published posts by featured flag', function () {
+    Post::factory()->featured()->create([
+        'slug' => 'featured-post',
+    ]);
+
+    Post::factory()->create([
+        'slug' => 'regular-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->getJson('/api/v1/posts?featured=true')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.slug', 'featured-post')
+        ->assertJsonPath('data.0.is_featured', true);
+});
+
 it('returns 404 for draft post detail', function () {
     Post::factory()->draft()->create(['slug' => 'draft-post']);
 
     $this->getJson('/api/v1/posts/draft-post')
         ->assertNotFound();
 });
+

--- a/apps/api/tests/Feature/Public/TagEndpointTest.php
+++ b/apps/api/tests/Feature/Public/TagEndpointTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+
+uses(RefreshDatabase::class);
+
+it('returns 200 with correct data structure and field shape', function () {
+    Tag::factory()->create([
+        'name' => 'Laravel',
+        'slug' => 'laravel',
+    ]);
+
+    $this->getJson('/api/v1/tags')
+        ->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => ['id', 'name', 'slug'],
+            ],
+        ])
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.name', 'Laravel')
+        ->assertJsonPath('data.0.slug', 'laravel');
+});
+
+it('returns tags ordered alphabetically by name', function () {
+    Tag::factory()->create(['name' => 'Zebra', 'slug' => 'zebra']);
+    Tag::factory()->create(['name' => 'Apple', 'slug' => 'apple']);
+    Tag::factory()->create(['name' => 'Mango', 'slug' => 'mango']);
+
+    $response = $this->getJson('/api/v1/tags')->assertOk();
+
+    $names = collect($response->json('data'))->pluck('name')->all();
+
+    expect($names)->toBe(['Apple', 'Mango', 'Zebra']);
+});
+
+it('returns 429 when the public-api rate limit is exceeded', function () {
+    $cacheKey = md5('public-api' . '127.0.0.1');
+
+    for ($i = 0; $i < 60; $i++) {
+        RateLimiter::hit($cacheKey, 60);
+    }
+
+    $this->getJson('/api/v1/tags')
+        ->assertTooManyRequests();
+});

--- a/docs/setup/agent-workflow.md
+++ b/docs/setup/agent-workflow.md
@@ -412,7 +412,7 @@ Rules:
 - Follow existing Laravel guard, middleware, and API response patterns.
 - Follow `docs/setup/security.md` backend conventions: auth gating, `$fillable` discipline, `$hidden`, input validation rules, throttle on mutations, Resource field whitelist.
 - Controllers must only contain the five RESTful methods: `index`, `show`, `store`, `update`, `destroy`. Do not add custom action methods (e.g. `comments()`, `history()`). If a resource needs its own endpoint, create a separate dedicated controller for it.
-- Controllers must not contain business logic. Validate input via FormRequest, call a service method, return a resource. That is all.
+- Controllers must not contain business logic. Validate input via FormRequest, call a service method, return a resource. That is all. No `Model::query()`, no `where()` chains, no Eloquent calls of any kind inside a controller — read or write. There is no "simple enough to skip the service" exception.
 - Models must not contain business logic. Models own columns (`$fillable`, `$hidden`, `casts()`), relationships, and nothing else.
 - Any logic that decides what to do with data belongs in a service under `app/Services/<Domain>/`. Create the service if it does not exist.
 - When adding, removing, or changing `/api/v1` routes, update Pest route coverage in `apps/api/tests/Feature/Routes/ApiRouteCoverageTest.php`.

--- a/docs/setup/techstack.md
+++ b/docs/setup/techstack.md
@@ -46,10 +46,10 @@ This document is the primary reference for any agent planning or implementing wo
 - Business logic lives in `apps/api/app/Services/`
 - Services are organised by domain: `Services/Profile/`, `Services/Post/`, `Services/Auth/`, etc.
 - Services are injectable via Laravel's service container
-- **Controllers are thin** — they validate input (via FormRequest), call one service method, and return a resource. No business logic inside a controller.
+- **Controllers are thin** — they validate input (via FormRequest), call one service method, and return a resource. That is all. No Eloquent queries, no `Model::query()`, no `where()` chains inside a controller — ever.
 - **Models are thin** — they define columns (`$fillable`, `$hidden`, `casts()`), relationships, and nothing else. No business logic inside a model.
-- Any logic that decides *what* to do with data (auto-set `published_at`, wrap in a transaction, fire an event, sync a pivot) belongs in a service method.
-- Every controller that writes data must go through a service. Read-only controllers (single-table, no logic) may query the model directly only when no transformation or decision is needed.
+- Any logic that decides *what* to do with data (filtering, sorting, eager loading, pagination, auto-setting `published_at`, firing an event, syncing a pivot) belongs in a service method.
+- Every controller — read or write — must call a service. There is no "simple enough to skip the service" exception.
 
 ### Repository conventions
 


### PR DESCRIPTION
## Summary

- **Landing page UI — Design phase** — Ported full landing page layout with Hero, Featured Posts, Latest Posts, and sidebar sections (About, Currently Reading, Recent Projects, Tags). Static placeholder data; no API calls. Newsletter section removed, deferred to a later phase.
- **Post endpoint — behavior tests** — Added `?featured=true` filter test to `PostEndpointTest`: seeds one featured + one non-featured post, asserts only the featured post is returned.
- **PostController refactor** — Extracted all Eloquent query logic from `PostController` into a new `PostService` (`app/Services/Post/PostService.php`). Controller now delegates to `postService->listPublished()` and `postService->findPublishedBySlug()` with zero model imports.
- **TagController refactor** — Same pattern: extracted query into `TagService` (`app/Services/Tag/TagService.php`). Controller is now query-free.
- **Tag endpoint — behavior tests** — Added `TagEndpointTest` covering field shape (`id`, `name`, `slug`), alphabetical ordering, and rate limit (429).
- **Docs** — Tightened `techstack.md` and `agent-workflow.md` to make the no-query-in-controller rule absolute with no read-only exception.

## Test plan

- [ ] `php artisan test --filter=PostEndpointTest` — 5 tests pass including the `?featured=true` filter test
- [ ] `php artisan test --filter=TagEndpointTest` — 3 tests pass: field shape, name ordering, rate limit
- [ ] `php artisan test` — full suite green, no regressions
- [ ] `GET /api/v1/posts?featured=true` returns only posts with `is_featured: true`
- [ ] `GET /api/v1/posts?per_page=6` returns up to 6 published posts ordered by `published_at` descending
- [ ] `GET /api/v1/tags` returns tags ordered alphabetically with `id`, `name`, `slug` fields
- [ ] Visit `/` — landing page renders with placeholder data in all sections (Featured Post, Latest Posts, Tags sidebar)
