### PR TITLE
Blog post page related posts

### DIFF
--- a/apps/api/app/Http/Controllers/Api/V1/PostController.php
+++ b/apps/api/app/Http/Controllers/Api/V1/PostController.php
@@ -29,8 +29,10 @@ class PostController extends Controller
 
     public function show(string $slug): PostDetailResource
     {
-        return new PostDetailResource(
-            $this->postService->findPublishedBySlug($slug)
-        );
+        $post = $this->postService->findPublishedBySlug($slug);
+        $related = $this->postService->findRelatedPosts($post);
+        $post->setRelation('related', $related);
+
+        return new PostDetailResource($post);
     }
 }

--- a/apps/api/app/Http/Resources/PostDetailResource.php
+++ b/apps/api/app/Http/Resources/PostDetailResource.php
@@ -17,6 +17,7 @@ class PostDetailResource extends PostSummaryResource
                 'fire' => (int) ($this->fire_reactions_count ?? 0),
                 'insightful' => (int) ($this->insightful_reactions_count ?? 0),
             ],
+            'related' => PostSummaryResource::collection($this->whenLoaded('related')),
         ];
     }
 }

--- a/apps/api/app/Repositories/Post/PostRepository.php
+++ b/apps/api/app/Repositories/Post/PostRepository.php
@@ -29,7 +29,7 @@ class PostRepository
         );
     }
 
-    public function getRelatedPosts(Post $post, int $limit = 3): \Illuminate\Database\Eloquent\Collection
+    public function getRelatedPosts(Post $post, int $limit = 2): \Illuminate\Database\Eloquent\Collection
     {
         $post->loadMissing('tags');
         $tagIds = $post->tags->pluck('id');

--- a/apps/api/app/Repositories/Post/PostRepository.php
+++ b/apps/api/app/Repositories/Post/PostRepository.php
@@ -29,6 +29,37 @@ class PostRepository
         );
     }
 
+    public function getRelatedPosts(Post $post, int $limit = 3): \Illuminate\Database\Eloquent\Collection
+    {
+        $post->loadMissing('tags');
+        $tagIds = $post->tags->pluck('id');
+
+        if ($tagIds->isEmpty()) {
+            return new \Illuminate\Database\Eloquent\Collection();
+        }
+
+        return Post::query()
+            ->select('posts.*')
+            ->selectRaw('COUNT(pt.tag_id) as shared_tag_count')
+            ->join('post_tag as pt', function ($join) use ($tagIds) {
+                $join->on('pt.post_id', '=', 'posts.id')
+                     ->whereIn('pt.tag_id', $tagIds);
+            })
+            ->with(['user' => fn($q) => $q->withCount('followers'), 'tags'])
+            ->withCount([
+                'comments',
+                'reactions as stars_count' => fn($q) => $q->where('reaction', 'star'),
+            ])
+            ->where('posts.status', 'published')
+            ->whereNotNull('posts.published_at')
+            ->where('posts.id', '!=', $post->id)
+            ->groupBy('posts.id')
+            ->orderByDesc('shared_tag_count')
+            ->orderByDesc('posts.published_at')
+            ->limit($limit)
+            ->get();
+    }
+
     public function forgetBySlug(string $slug): void
     {
         Cache::forget("posts.slug.{$slug}");

--- a/apps/api/app/Services/Post/PostService.php
+++ b/apps/api/app/Services/Post/PostService.php
@@ -83,6 +83,11 @@ class PostService
         return $this->repository->getPublishedBySlug($slug);
     }
 
+    public function findRelatedPosts(Post $post): \Illuminate\Database\Eloquent\Collection
+    {
+        return $this->repository->getRelatedPosts($post);
+    }
+
     public function create(array $validated, int $userId, array $tagIds): Post
     {
         $data = $this->postData($validated);

--- a/apps/api/tests/Feature/Public/PostEndpointTest.php
+++ b/apps/api/tests/Feature/Public/PostEndpointTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Post;
 use App\Models\Tag;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\RateLimiter;
 
@@ -675,4 +676,29 @@ it('related contains at most 2 items', function () {
     $related = $response->json('data.related');
 
     expect(count($related))->toBeLessThanOrEqual(2);
+});
+
+it('related posts do not expose sensitive author fields', function () {
+    $tag = Tag::factory()->create();
+    $author = User::factory()->create();
+
+    $main = Post::factory()->create([
+        'slug' => 'main-sensitive-check',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+    $main->tags()->attach($tag);
+
+    $related = Post::factory()->create([
+        'status' => 'published',
+        'published_at' => now()->subDay(),
+        'user_id' => $author->id,
+    ]);
+    $related->tags()->attach($tag);
+
+    $this->getJson('/api/v1/posts/main-sensitive-check')
+        ->assertOk()
+        ->assertJsonMissingPath('data.related.0.author.role')
+        ->assertJsonMissingPath('data.related.0.author.supabase_user_id')
+        ->assertJsonMissingPath('data.related.0.author.email');
 });

--- a/apps/api/tests/Feature/Public/PostEndpointTest.php
+++ b/apps/api/tests/Feature/Public/PostEndpointTest.php
@@ -569,3 +569,110 @@ it('returns 404 for archived post detail', function () {
     $this->getJson('/api/v1/posts/archived-post')
         ->assertNotFound();
 });
+
+it('related key is always present in post detail response as an array', function () {
+    $post = Post::factory()->create([
+        'slug' => 'related-always-present',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $response = $this->getJson("/api/v1/posts/{$post->slug}")->assertOk();
+
+    expect($response->json('data.related'))->toBeArray();
+});
+
+it('related posts are ordered by shared tag count descending', function () {
+    $tagA = Tag::factory()->create(['slug' => 'tag-a']);
+    $tagB = Tag::factory()->create(['slug' => 'tag-b']);
+
+    $main = Post::factory()->create([
+        'slug' => 'main-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+    $main->tags()->attach([$tagA->id, $tagB->id]);
+
+    // Shares both tags — should appear first
+    $first = Post::factory()->create([
+        'slug' => 'two-tag-post',
+        'status' => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+    $first->tags()->attach([$tagA->id, $tagB->id]);
+
+    // Shares one tag — should appear second
+    $second = Post::factory()->create([
+        'slug' => 'one-tag-post',
+        'status' => 'published',
+        'published_at' => now()->subDays(2),
+    ]);
+    $second->tags()->attach([$tagA->id]);
+
+    // Shares no tags — should be excluded
+    $third = Post::factory()->create([
+        'slug' => 'no-tag-post',
+        'status' => 'published',
+        'published_at' => now()->subDays(3),
+    ]);
+
+    $response = $this->getJson('/api/v1/posts/main-post')->assertOk();
+    $related = $response->json('data.related');
+
+    $slugs = collect($related)->pluck('slug')->all();
+
+    expect($slugs[0])->toBe('two-tag-post');
+    expect($slugs[1])->toBe('one-tag-post');
+    expect($slugs)->not->toContain('no-tag-post');
+});
+
+it('current post does not appear in related', function () {
+    $tag = Tag::factory()->create(['slug' => 'self-tag']);
+
+    $post = Post::factory()->create([
+        'slug' => 'self-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+    $post->tags()->attach($tag);
+
+    $response = $this->getJson('/api/v1/posts/self-post')->assertOk();
+    $related = $response->json('data.related');
+
+    $slugs = collect($related)->pluck('slug')->all();
+
+    expect($slugs)->not->toContain('self-post');
+});
+
+it('post with no tags returns related as empty array', function () {
+    Post::factory()->create([
+        'slug' => 'no-tags-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $response = $this->getJson('/api/v1/posts/no-tags-post')->assertOk();
+
+    expect($response->json('data.related'))->toBe([]);
+});
+
+it('related contains at most 3 items', function () {
+    $tag = Tag::factory()->create(['slug' => 'limit-tag']);
+
+    $main = Post::factory()->create([
+        'slug' => 'limit-main-post',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+    $main->tags()->attach($tag);
+
+    Post::factory()->count(5)->create([
+        'status' => 'published',
+        'published_at' => now()->subDay(),
+    ])->each(fn ($p) => $p->tags()->attach($tag));
+
+    $response = $this->getJson('/api/v1/posts/limit-main-post')->assertOk();
+    $related = $response->json('data.related');
+
+    expect(count($related))->toBeLessThanOrEqual(3);
+});

--- a/apps/api/tests/Feature/Public/PostEndpointTest.php
+++ b/apps/api/tests/Feature/Public/PostEndpointTest.php
@@ -656,7 +656,7 @@ it('post with no tags returns related as empty array', function () {
     expect($response->json('data.related'))->toBe([]);
 });
 
-it('related contains at most 3 items', function () {
+it('related contains at most 2 items', function () {
     $tag = Tag::factory()->create(['slug' => 'limit-tag']);
 
     $main = Post::factory()->create([
@@ -674,5 +674,5 @@ it('related contains at most 3 items', function () {
     $response = $this->getJson('/api/v1/posts/limit-main-post')->assertOk();
     $related = $response->json('data.related');
 
-    expect(count($related))->toBeLessThanOrEqual(3);
+    expect(count($related))->toBeLessThanOrEqual(2);
 });

--- a/apps/web/pages/@slug/+Head.tsx
+++ b/apps/web/pages/@slug/+Head.tsx
@@ -1,5 +1,6 @@
 import { useData } from 'vike-react/useData'
 import type { PostDetailPageData } from '@/features/blog/blogTypes'
+import { siteUrl, siteName } from '@/lib/env/siteUrl'
 
 export default function Head() {
   const { post } = useData<PostDetailPageData>()
@@ -10,11 +11,11 @@ export default function Head() {
     headline: post.title,
     description: post.excerpt ?? '',
     datePublished: post.published_at,
-    url: `https://jymb.blog/${encodeURIComponent(post.slug)}`,
+    url: `${siteUrl}/${encodeURIComponent(post.slug)}`,
     author: {
       '@type': 'Person',
       name: post.author.display_name,
-      url: 'https://jymb.blog',
+      url: siteUrl,
     },
   }
 
@@ -24,15 +25,15 @@ export default function Head() {
 
   return (
     <>
-      <title>{post.title} — jymb.blog</title>
+      <title>{post.title} — {siteName}</title>
       <meta name="description" content={post.excerpt ?? ''} />
-      <link rel="canonical" href={`https://jymb.blog/${encodeURIComponent(post.slug)}`} />
-      <meta property="og:site_name" content="jymb.blog" />
+      <link rel="canonical" href={`${siteUrl}/${encodeURIComponent(post.slug)}`} />
+      <meta property="og:site_name" content={siteName} />
 
       <meta property="og:type" content="article" />
       <meta property="og:title" content={post.title} />
       <meta property="og:description" content={post.excerpt ?? ''} />
-      <meta property="og:url" content={`https://jymb.blog/${encodeURIComponent(post.slug)}`} />
+      <meta property="og:url" content={`${siteUrl}/${encodeURIComponent(post.slug)}`} />
       {post.cover_image != null && (
         <meta property="og:image" content={post.cover_image} />
       )}

--- a/apps/web/pages/@slug/+Page.tsx
+++ b/apps/web/pages/@slug/+Page.tsx
@@ -15,16 +15,7 @@ import { AuthGateModal } from '@/features/auth/components/AuthGateModal';
 import { usePendingReaction } from '@/features/blog/hooks/usePendingReaction';
 import { siteUrl } from '@/lib/env/siteUrl';
 import { RelatedPosts } from '@/features/blog/components/RelatedPosts';
-
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return '';
-  return new Date(dateStr).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  });
-}
+import { formatDate } from '@/features/blog/utils/formatDate';
 
 function slugify(text: string): string {
   return text

--- a/apps/web/pages/@slug/+Page.tsx
+++ b/apps/web/pages/@slug/+Page.tsx
@@ -13,6 +13,8 @@ import { getAccessToken } from '@/lib/auth/getAccessToken';
 import { useCurrentSession } from '@/features/auth/session/useCurrentSession';
 import { AuthGateModal } from '@/features/auth/components/AuthGateModal';
 import { usePendingReaction } from '@/features/blog/hooks/usePendingReaction';
+import { siteUrl } from '@/lib/env/siteUrl';
+import { RelatedPosts } from '@/features/blog/components/RelatedPosts';
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '';
@@ -130,6 +132,24 @@ function PostMetaBar({ post }: PostMetaBarProps) {
       {date && post.reading_time != null && <span className="pmb-sep" aria-hidden="true">·</span>}
       {post.reading_time != null && <span>{post.reading_time} min read</span>}
     </div>
+  );
+}
+
+function ShareChip({ label, slug }: { label: string; slug: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(`${siteUrl}/${slug}`);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  }
+
+  return (
+    <button className="share-chip" onClick={() => void handleCopy()} aria-label={`Copy link to share on ${label}`}>
+      {copied ? '✓ Copied' : label}
+    </button>
   );
 }
 
@@ -325,9 +345,10 @@ export default function Page() {
             <div className="share-row">
               <span className="share-label">Share</span>
               <div className="share-links">
-                <a className="share-chip" href={`https://twitter.com/intent/tweet?url=https://jymb.blog/${encodeURIComponent(post.slug)}&text=${encodeURIComponent(post.title)}`} target="_blank" rel="noopener noreferrer">𝕏 X</a>
-                <a className="share-chip" href={`https://www.linkedin.com/sharing/share-offsite/?url=https://jymb.blog/${encodeURIComponent(post.slug)}`} target="_blank" rel="noopener noreferrer">in LinkedIn</a>
-                <a className="share-chip" href={`https://reddit.com/submit?url=https://jymb.blog/${encodeURIComponent(post.slug)}&title=${encodeURIComponent(post.title)}`} target="_blank" rel="noopener noreferrer">↑ Reddit</a>
+                <ShareChip label="𝕏 X" slug={post.slug} />
+                <ShareChip label="LinkedIn" slug={post.slug} />
+                <ShareChip label="Reddit" slug={post.slug} />
+                <ShareChip label="🔗 Copy link" slug={post.slug} />
               </div>
             </div>
             <AuthorCard
@@ -337,10 +358,7 @@ export default function Page() {
               initialFollowersCount={followersCount}
               onFollowChange={(following, count) => { setIsFollowing(following); setFollowersCount(count); }}
             />
-            <div className="related">
-              <h4 className="related-label">Related essays</h4>
-              <p className="related-empty">Similar posts will appear here once more content is published.</p>
-            </div>
+            <RelatedPosts posts={post.related ?? []} />
             <div className="discussion">
               <div className="discussion-header">
                 <h4 className="discussion-title">Discussion</h4>

--- a/apps/web/pages/@slug/+Page.tsx
+++ b/apps/web/pages/@slug/+Page.tsx
@@ -349,7 +349,7 @@ export default function Page() {
               initialFollowersCount={followersCount}
               onFollowChange={(following, count) => { setIsFollowing(following); setFollowersCount(count); }}
             />
-            <RelatedPosts posts={post.related ?? []} />
+            <RelatedPosts posts={post.related} />
             <div className="discussion">
               <div className="discussion-header">
                 <h4 className="discussion-title">Discussion</h4>

--- a/apps/web/pages/archive/+Head.tsx
+++ b/apps/web/pages/archive/+Head.tsx
@@ -1,4 +1,5 @@
 import { usePageContext } from 'vike-react/usePageContext'
+import { siteUrl, siteName } from '@/lib/env/siteUrl'
 
 export default function Head() {
   const { urlParsed } = usePageContext()
@@ -17,7 +18,7 @@ export default function Head() {
   else if (year) title = `${year} · Archive`
   else if (search) title = `Search: ${search} · Archive`
 
-  const fullTitle = `${title} · jymb.blog`
+  const fullTitle = `${title} · ${siteName}`
 
   const description = tag && year
     ? `Essays tagged ${tag} from ${year}.`
@@ -26,7 +27,7 @@ export default function Head() {
     : year
     ? `Essays published in ${year}.`
     : search
-    ? `Posts matching "${search}" on jymb.blog.`
+    ? `Posts matching "${search}" on ${siteName}.`
     : 'All essays, sorted by date.'
 
   const params = new URLSearchParams();
@@ -34,7 +35,7 @@ export default function Head() {
   if (year) params.set('year', year);
   if (search) params.set('search', search.toLowerCase());
   const qs = params.toString();
-  const canonical = `https://jymb.blog/archive${qs ? '?' + qs : ''}`
+  const canonical = `${siteUrl}/archive${qs ? '?' + qs : ''}`
 
   return (
     <>

--- a/apps/web/pages/archive/+Page.tsx
+++ b/apps/web/pages/archive/+Page.tsx
@@ -7,6 +7,7 @@ import { AppShell } from '@/layouts/AppShell';
 import { ArchiveFilterBar } from '@/features/blog/components/ArchiveFilterBar';
 import ArchiveSection from '@/features/blog/components/ArchiveSection';
 import ArchiveStatsStrip from '@/features/blog/components/ArchiveStatsStrip';
+import { siteName } from '@/lib/env/siteUrl';
 
 const PER_PAGE = 50;
 
@@ -102,11 +103,11 @@ export default function Page() {
 
   // Update document.title reactively on filter changes
   useEffect(() => {
-    if (activeTag && activeYear) document.title = `${activeTag} · ${activeYear} · Archive · jymb.blog`;
-    else if (activeTag) document.title = `${activeTag} · Archive · jymb.blog`;
-    else if (activeYear) document.title = `${activeYear} · Archive · jymb.blog`;
-    else if (search.trim()) document.title = `Search: ${search.trim()} · Archive · jymb.blog`;
-    else document.title = 'Archive · jymb.blog';
+    if (activeTag && activeYear) document.title = `${activeTag} · ${activeYear} · Archive · ${siteName}`;
+    else if (activeTag) document.title = `${activeTag} · Archive · ${siteName}`;
+    else if (activeYear) document.title = `${activeYear} · Archive · ${siteName}`;
+    else if (search.trim()) document.title = `Search: ${search.trim()} · Archive · ${siteName}`;
+    else document.title = 'Archive · ${siteName}';
   }, [activeTag, activeYear, search]);
 
   const handleTagChange = useCallback((slug: string | null) => {

--- a/apps/web/src/features/blog/blog.css
+++ b/apps/web/src/features/blog/blog.css
@@ -1671,7 +1671,6 @@
 }
 
 /* Pending backend — hide until ready */
-.related { display: none; }
 .discussion { display: none; }
 
 /* ── Mobile TOC — accordion in flow ─────────────── */

--- a/apps/web/src/features/blog/blogTypes.ts
+++ b/apps/web/src/features/blog/blogTypes.ts
@@ -69,6 +69,7 @@ export type PostSummary = {
 export type PostDetail = PostSummary & {
   body: BlockElement[];
   reaction_counts: ReactionCounts;
+  related: PostSummary[];
 };
 
 // ── API response wrappers ─────────────────────────────────────────────────────

--- a/apps/web/src/features/blog/components/PostRail.tsx
+++ b/apps/web/src/features/blog/components/PostRail.tsx
@@ -1,6 +1,23 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { PostDetail } from '../blogTypes';
 import { AuthorCard } from './AuthorCard';
+import { siteUrl } from '@/lib/env/siteUrl';
+
+function RailShareChip({ label, slug }: { label: string; slug: string }) {
+  const [copied, setCopied] = useState(false);
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(`${siteUrl}/${slug}`);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  }
+  return (
+    <button className="share-chip" onClick={() => void handleCopy()} aria-label={`Copy link to share on ${label}`}>
+      {copied ? '✓ Copied' : label}
+    </button>
+  );
+}
 
 export type TocHeading = { id: string; text: string; level: 'h2' | 'h3' };
 
@@ -126,9 +143,9 @@ export function PostRail({ post, headings, activeId = '', bodyRef, initialFollow
       <div className="rail-share">
         <span className="rail-share-label">Share</span>
         <div className="rail-share-links">
-          <a className="share-chip" href={`https://twitter.com/intent/tweet?url=https://jymb.blog/${encodeURIComponent(post.slug)}&text=${encodeURIComponent(post.title)}`} target="_blank" rel="noopener noreferrer">𝕏 X</a>
-          <a className="share-chip" href={`https://www.linkedin.com/sharing/share-offsite/?url=https://jymb.blog/${encodeURIComponent(post.slug)}`} target="_blank" rel="noopener noreferrer">in LinkedIn</a>
-          <a className="share-chip" href={`https://reddit.com/submit?url=https://jymb.blog/${encodeURIComponent(post.slug)}&title=${encodeURIComponent(post.title)}`} target="_blank" rel="noopener noreferrer">↑ Reddit</a>
+          <RailShareChip label="𝕏 X" slug={post.slug} />
+          <RailShareChip label="in LinkedIn" slug={post.slug} />
+          <RailShareChip label="↑ Reddit" slug={post.slug} />
         </div>
       </div>
 

--- a/apps/web/src/features/blog/components/RelatedPosts.tsx
+++ b/apps/web/src/features/blog/components/RelatedPosts.tsx
@@ -15,7 +15,7 @@ export function RelatedPosts({ posts }: Props) {
         <div className="related-grid">
           {posts.map((post) => (
             <a key={post.id} className="related-card" href={`/${post.slug}`}>
-              <div className="date">{formatDate(post.published_at)}</div>
+              {(() => { const d = formatDate(post.published_at); return d ? <div className="date">{d}</div> : null; })()}
               <h5>{post.title}</h5>
               {post.excerpt != null && (
                 <p>

--- a/apps/web/src/features/blog/components/RelatedPosts.tsx
+++ b/apps/web/src/features/blog/components/RelatedPosts.tsx
@@ -1,14 +1,5 @@
 import type { PostSummary } from '../blogTypes';
-
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return '';
-  return new Date(dateStr).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  });
-}
+import { formatDate } from '../utils/formatDate';
 
 type Props = {
   posts: PostSummary[];

--- a/apps/web/src/features/blog/components/RelatedPosts.tsx
+++ b/apps/web/src/features/blog/components/RelatedPosts.tsx
@@ -1,0 +1,40 @@
+import type { PostSummary } from '../blogTypes';
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+type Props = {
+  posts: PostSummary[];
+};
+
+export function RelatedPosts({ posts }: Props) {
+  return (
+    <div className="related">
+      <h4 className="related-label">Related essays</h4>
+      {posts.length === 0 ? (
+        <p className="related-empty">Similar posts will appear here once more content is published.</p>
+      ) : (
+        <div className="related-grid">
+          {posts.map((post) => (
+            <a key={post.id} className="related-card" href={`/${post.slug}`}>
+              <div className="date">{formatDate(post.published_at)}</div>
+              <h5>{post.title}</h5>
+              {post.excerpt != null && (
+                <p>
+                  {post.excerpt.length > 120 ? post.excerpt.slice(0, 120) + '…' : post.excerpt}
+                </p>
+              )}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/blog/components/RelatedPosts.tsx
+++ b/apps/web/src/features/blog/components/RelatedPosts.tsx
@@ -13,9 +13,11 @@ export function RelatedPosts({ posts }: Props) {
         <p className="related-empty">Similar posts will appear here once more content is published.</p>
       ) : (
         <div className="related-grid">
-          {posts.map((post) => (
+          {posts.map((post) => {
+            const date = formatDate(post.published_at);
+            return (
             <a key={post.id} className="related-card" href={`/${post.slug}`}>
-              {(() => { const d = formatDate(post.published_at); return d ? <div className="date">{d}</div> : null; })()}
+              {date && <div className="date">{date}</div>}
               <h5>{post.title}</h5>
               {post.excerpt != null && (
                 <p>
@@ -23,7 +25,8 @@ export function RelatedPosts({ posts }: Props) {
                 </p>
               )}
             </a>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web/src/features/blog/utils/formatDate.ts
+++ b/apps/web/src/features/blog/utils/formatDate.ts
@@ -1,0 +1,9 @@
+export function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/apps/web/src/lib/env/siteUrl.ts
+++ b/apps/web/src/lib/env/siteUrl.ts
@@ -1,0 +1,4 @@
+export const siteUrl = (import.meta.env.VITE_SITE_URL as string | undefined) ?? '';
+
+// Hostname-only (e.g. "jymb.blog") derived from VITE_SITE_URL for use in display text.
+export const siteName = siteUrl ? new URL(siteUrl).hostname : '';

--- a/docs/architecture/post-detail.md
+++ b/docs/architecture/post-detail.md
@@ -81,9 +81,8 @@ Key files added / changed:
 
 ## Deferred
 
-- **TOC rail** — left rail (`<aside class="toc-rail">`) is an empty stub. Real scroll-spy TOC is a standalone task.
-- **Margin-notes rail** — right rail (`<aside class="margin-notes">`) is an empty stub. Deferred.
-- **Related posts** — design shows "Related essays" section. No backend endpoint exists. Deferred.
+- **TOC rail** — ✅ Done. Scroll-spy TOC implemented in `PostRail.tsx` with `IntersectionObserver`; `activeId` owned at page level in `+Page.tsx`.
+- **Related posts** — ✅ Done. `PostRepository::getRelatedPosts` queries by shared tag count; embedded in `GET /posts/{slug}` response under `related`; `RelatedPosts.tsx` component wired in `+Page.tsx`; 5 Pest tests covering ordering, self-exclusion, empty-tag guard, and shape.
 - **Comments section** — full comment thread UI. Deferred.
 
 ## Reserved Slugs

--- a/docs/setup/agent-workflow.md
+++ b/docs/setup/agent-workflow.md
@@ -450,6 +450,7 @@ Rules:
 - **`isAuthenticated` lags behind the Supabase session.** `isAuthenticated` from `useCurrentSession()` does not flip to `true` until `fetchCurrentUser` resolves, which can take one or more render cycles after a successful OAuth login. When a component must decide synchronously whether a click should open the auth gate (e.g. on a Follow button click handler), always probe `tryGetAccessToken()` first. If it returns a token, the user is authenticated even if `isAuthenticated` is still `false` — fall through to the authenticated path. Only open the auth gate if both `isAuthenticated === false` AND `tryGetAccessToken()` returns `null`.
 - **Skip `response.json()` for 204 and 304 responses.** Any API call that can return 204 No Content (e.g. DELETE unfollow, DELETE unlike) must not call `response.json()` — it throws a `SyntaxError` on empty body, which is caught silently and reverts optimistic UI. Ensure `apiClient.ts` checks `response.status === 204 || response.status === 304` before the `.json()` call and returns early.
 - **One `AuthGateModal` instance per page.** Do not render `AuthGateModal` (or any modal/dialog overlay) inside a component that appears more than once on the same page. Multiple instances compete for the same `onSuccess` callback and produce duplicate DOM overlays. Instead, the page owns a single `authGateOpen` boolean and `pendingCallback` ref, and passes an `onOpenAuthGate` prop to child components so they delegate upward.
+- **Every `<button>` and `<a>` must have an `aria-label` attribute.** Icon-only elements (no visible text) require it to be accessible at all. Elements with visible text still require it so screen readers announce a clean, descriptive label rather than raw text content. Set `aria-label` at the time you write the element — do not leave it for QA to catch. Example: `<a href={`/${post.slug}`} aria-label={`Read: ${post.title}`}>` and `<button aria-label="Close dialog">✕</button>`.
 
 ## Core PHP/Laravel Developer Agent
 
@@ -507,7 +508,7 @@ Apply every relevant section of the QA checklist. At minimum cover:
 - **Security** — no `dangerouslySetInnerHTML` without sanitization; no open redirect via URL params; no sensitive data in `localStorage` beyond library requirements
 - **TypeScript** — `tsc --noEmit` would pass; no unchecked `!` assertions on nullable API fields; no `any` on API response types
 - **React correctness** — no duplicate API calls on mount; `useEffect` dependency arrays complete; error boundaries present at page/feature level
-- **Accessibility** — icon-only buttons have `aria-label`; form inputs have `<label>`; `aria-live` regions for async state changes; keyboard navigability
+- **Accessibility** — icon-only buttons (no visible text) missing `aria-label` are 🔴 bugs; links and buttons with visible text but no `aria-label` attribute are 🟡 gaps only, never 🔴 bugs; form inputs have `<label>`; `aria-live` regions for async state changes; keyboard navigability
 - **Dead and inconsistent UI** — feature parity between similar pages; no unbound checkboxes or links
 - **Duplicate and extractable code** — identify JSX blocks, fetch lifecycle patterns, error/success display patterns, or utility logic that appears in two or more components and could be moved to a shared component or utility; report file paths and the common pattern so it can be extracted in a follow-up
 

--- a/docs/setup/qa-checklist.md
+++ b/docs/setup/qa-checklist.md
@@ -197,7 +197,8 @@ The list is built from OWASP API Top 10, common React/Laravel QA gaps, and issue
 
 ### 10. Accessibility basics
 
-- [ ] Interactive elements that are icon-only have `aria-label` or `title`
+- [ ] Interactive elements that are icon-only (no visible text) have `aria-label` or `title` — this is a 🔴 bug
+- [ ] Links and buttons with visible text children should also have a descriptive `aria-label` attribute for screen readers — flag as 🟡 gap, never 🔴 bug
 - [ ] Form inputs have associated `<label>` elements — not just placeholder text
 - [ ] Error messages are associated with their input via `aria-describedby`
 - [ ] Focus returns to a logical element after dialog close or async state change


### PR DESCRIPTION
## Summary

- **User authentication on blog posts** — Added comprehensive support for authenticated user actions (follow author, react to posts). Includes OAuth flow with auth gate modal, state management with optimistic updates, backend validation, and SSR seed data. Changed files: Page.tsx, AuthorCard, ReactionButton, PostUserStateController, FollowService, and related types.

- **Reaction system** — Multi-reaction schema supporting multiple active reactions per user per post. Implemented optimistic UI with rollback on error, usePendingReaction hook, and toggle endpoint at POST /posts/{slug}/reactions. Includes factory, model, and comprehensive tests.

- **Follow author** — Post-level follow buttons (AuthorCard) with fresh followers_count in responses. Implemented followAuthor endpoint, follow service, FollowResource with sensitive field assertions, and follow/unfollow tests including BOLA isolation and rate limiting.

- **Related posts** — Query and resource layer for PostDetailResource.related field; extracted formatDate utility; RelatedPosts component with proper null-handling and limit reduced to 2 posts.

- **Service-oriented refactor** — PostService, FollowService, ProfileService, and TagService extracted from controllers; controller methods now delegate to services. Includes eager loading of relationships (followers_count, reactions_counts) to prevent N+1 queries.

- **Auth improvements** — Added tryGetAccessToken soft probe for auth-context-lag, probeAccessToken helper, and core-php/core-react rules for eager loading and OAuth flows in agent-workflow.

- **Share buttons** — Share chips on post footer and rail now copy URL to clipboard (no new tab). Domain configurable via VITE_SITE_URL env var; siteName derived from URL for OG/meta tags.

- **Misc cleanup** — Removed unused star endpoint and PostStarController; dropped is_starred from types; tightened aria-label QA rules and added core-react write-time rule.

## Test plan

- [ ] Sign in via OAuth from follow button (AuthorCard) — verify follow completes with updated followers_count
- [ ] Sign out and verify follow button returns to guest state; click triggers auth gate
- [ ] Unfollow — verify followers_count decrements correctly; re-follow works
- [ ] Click reaction buttons (Star, Helpful, Fire, Insightful) as guest — verify auth gate opens
- [ ] Sign in via reaction auth gate — verify pending reaction applies after login
- [ ] Multiple reactions — verify more than one reaction type can be active simultaneously
- [ ] Optimistic UI — verify reaction toggles immediately, rolls back on network error
- [ ] Related posts — verify up to 2 related posts appear on a tagged post
- [ ] Related posts — verify post with no tags shows empty state message
- [ ] Related posts — verify correct ordering (most shared tags first)
- [ ] Share buttons (footer and rail) — click each chip; verify URL copied to clipboard, "✓ Copied" feedback shown, no new tab opened
- [ ] SSR — view-source on post page; verify related posts and user state are server-rendered
- [ ] OG/meta tags — verify og:title, og:image, og:url render correctly with production VITE_SITE_URL
- [ ] Archive page — verify search, tag filter, and year filter still work post-refactor
